### PR TITLE
feat: add configurable game loader subsystem for QA/RL game startup

### DIFF
--- a/configs/games/breakout-71.yaml
+++ b/configs/games/breakout-71.yaml
@@ -1,0 +1,29 @@
+# Breakout 71 — browser game loader configuration
+#
+# Roguelite breakout game served by Parcel dev server.
+# Source: https://gitlab.com/lecarore/breakout71
+# Testbed fork: F:\work\breakout71-testbed
+#
+# Usage:
+#   from src.game_loader import load_game_config, create_loader
+#   config = load_game_config("breakout-71")
+#   loader = create_loader(config)
+#   loader.start()
+
+name: breakout-71
+game_dir: F:\work\breakout71-testbed
+loader_type: breakout-71
+
+# -- Build / serve -----------------------------------------------------
+install_command: npm install
+serve_command: npx parcel src/index.html --no-cache
+serve_port: 1234
+url: http://localhost:1234
+readiness_endpoint: http://localhost:1234
+
+# -- Readiness ---------------------------------------------------------
+readiness_timeout_s: 120.0
+readiness_poll_interval_s: 2.0
+
+# -- Window identification (for WindowCapture) -------------------------
+window_title: Breakout

--- a/docs/api/game_loader.rst
+++ b/docs/api/game_loader.rst
@@ -1,0 +1,53 @@
+Game Loader Module
+==================
+
+Configurable game loading for QA testing and RL training.
+
+.. automodule:: src.game_loader
+   :no-members:
+
+GameLoaderConfig
+----------------
+
+.. autoclass:: src.game_loader.GameLoaderConfig
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+GameLoader
+----------
+
+.. autoclass:: src.game_loader.GameLoader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+GameLoaderError
+---------------
+
+.. autoclass:: src.game_loader.GameLoaderError
+   :members:
+   :show-inheritance:
+
+BrowserGameLoader
+-----------------
+
+.. autoclass:: src.game_loader.BrowserGameLoader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Breakout71Loader
+----------------
+
+.. autoclass:: src.game_loader.Breakout71Loader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Factory
+-------
+
+.. autofunction:: src.game_loader.create_loader
+
+.. autofunction:: src.game_loader.factory.register_loader

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,3 +11,4 @@ Auto-generated documentation from source code docstrings and type hints.
    env
    perception
    reporting
+   game_loader

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,7 @@ autodoc_mock_imports = [
     "imagehash",
     "pandas",
     "polars",
+    "yaml",
 ]
 
 # Napoleon settings (for Google-style docstrings)

--- a/docs/specs/game_loader.md
+++ b/docs/specs/game_loader.md
@@ -1,0 +1,2 @@
+```{include} ../../documentation/specs/game_loader_spec.md
+```

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -9,4 +9,5 @@ breakout71_env
 oracle_system
 capture_and_input
 reporting_system
+game_loader
 ```

--- a/documentation/specs/game_loader_spec.md
+++ b/documentation/specs/game_loader_spec.md
@@ -1,0 +1,309 @@
+# Game Loader Spec
+
+> Reference design for the game loader subsystem.  The game loader
+> manages the full lifecycle of getting a game running and reachable
+> so that the QA / RL layer can interact with it.
+
+## Overview
+
+Before any QA testing or RL training can happen, the game under test
+must be running and reachable.  The game loader subsystem provides a
+configurable, extensible mechanism for this:
+
+1. **Install** dependencies (e.g. `npm install`)
+2. **Serve** the game (e.g. start a Parcel dev server)
+3. **Wait** until the game is ready (HTTP readiness polling)
+4. **Expose** the URL for capture / input layers to connect to
+5. **Tear down** the game process when testing is complete
+
+The subsystem is designed to be game-agnostic.  Each game is described
+by a declarative YAML configuration, and the loader class hierarchy
+handles the mechanics.
+
+## Architecture
+
+```
+                      ┌─────────────────┐
+                      │ GameLoaderConfig │  ← YAML file (configs/games/*.yaml)
+                      └────────┬────────┘
+                               │
+                      ┌────────▼────────┐
+                      │   GameLoader    │  ← Abstract base class
+                      │   (ABC)         │
+                      └────────┬────────┘
+                               │
+                ┌──────────────┼──────────────┐
+                │                             │
+       ┌────────▼────────┐           ┌────────▼────────┐
+       │ BrowserGame     │           │  (future)       │
+       │ Loader          │           │ EmulatorLoader  │
+       └────────┬────────┘           │ NativeLoader    │
+                │                    └─────────────────┘
+       ┌────────▼────────┐
+       │ Breakout71      │
+       │ Loader          │
+       └─────────────────┘
+```
+
+The factory function `create_loader(config)` maps a config's
+`loader_type` field to the correct class.
+
+## Configuration
+
+Each game is described by a `GameLoaderConfig` dataclass.  Configs can
+be constructed directly in Python or loaded from YAML files stored in
+`configs/games/`.
+
+### YAML Schema
+
+| Field                     | Type   | Default                                   | Description                                             |
+|---------------------------|--------|-------------------------------------------|---------------------------------------------------------|
+| `name`                    | str    | *(required)*                              | Human-readable game identifier                          |
+| `game_dir`                | str    | *(required)*                              | Path to the game's source repository                    |
+| `loader_type`             | str    | `"browser"`                               | Loader class to use (`"browser"`, `"breakout-71"`, ...) |
+| `install_command`         | str    | `"npm install"`                           | Shell command to install dependencies                   |
+| `serve_command`           | str    | `"npx parcel src/index.html --no-cache"`  | Shell command to start the dev server                   |
+| `serve_port`              | int    | `1234`                                    | Port the dev server listens on                          |
+| `url`                     | str    | `"http://localhost:1234"`                 | Full URL the game is reachable at                       |
+| `readiness_endpoint`      | str    | *(defaults to `url`)*                     | URL to poll for readiness                               |
+| `readiness_timeout_s`     | float  | `120.0`                                   | Max seconds to wait for readiness                       |
+| `readiness_poll_interval_s` | float | `2.0`                                    | Seconds between readiness polls                         |
+| `window_title`            | str    | `None`                                    | Browser window title (for `WindowCapture`)              |
+| `env_vars`                | dict   | `{}`                                      | Extra environment variables for the serve process       |
+
+### Example YAML (`configs/games/breakout-71.yaml`)
+
+```yaml
+name: breakout-71
+game_dir: F:\work\breakout71-testbed
+loader_type: breakout-71
+
+install_command: npm install
+serve_command: npx parcel src/index.html --no-cache
+serve_port: 1234
+url: http://localhost:1234
+readiness_endpoint: http://localhost:1234
+
+readiness_timeout_s: 120.0
+readiness_poll_interval_s: 2.0
+
+window_title: Breakout
+```
+
+### Loading a Config
+
+```python
+from src.game_loader import load_game_config
+
+config = load_game_config("breakout-71")
+# Searches configs/games/breakout-71.yaml
+```
+
+A custom search directory can be provided:
+
+```python
+config = load_game_config("my-game", configs_dir="/path/to/configs")
+```
+
+## GameLoader Lifecycle
+
+The base `GameLoader` defines four lifecycle methods:
+
+| Method       | Purpose                                          |
+|--------------|--------------------------------------------------|
+| `setup()`    | One-time preparation (install deps, clear caches) |
+| `start()`    | Launch the game and block until ready             |
+| `is_ready()` | Check if the game is responding                   |
+| `stop()`     | Tear down the game process and free resources      |
+
+### Context Manager
+
+`GameLoader` implements `__enter__` / `__exit__` for convenient
+lifecycle management:
+
+```python
+from src.game_loader import load_game_config, create_loader
+
+config = load_game_config("breakout-71")
+with create_loader(config) as loader:
+    print(f"Game ready at {loader.url}")
+    # … run QA / RL …
+# loader.stop() called automatically
+```
+
+### Properties
+
+| Property   | Type         | Description                                      |
+|------------|--------------|--------------------------------------------------|
+| `name`     | `str`        | Human-readable game identifier                    |
+| `url`      | `str | None` | URL when running, `None` when stopped             |
+| `running`  | `bool`       | Whether the game process is currently active      |
+
+## BrowserGameLoader
+
+Handles browser-based games served by a local dev server (Parcel, Vite,
+Webpack Dev Server, etc.).
+
+### setup()
+
+1. Validate that `game_dir` exists
+2. Run `install_command` via `subprocess.run()` in `game_dir`
+3. Raise `GameLoaderError` if the command fails
+
+Skipped if `install_command` is `None` or empty.
+
+### start()
+
+1. Spawn `serve_command` as a background subprocess via `subprocess.Popen`
+2. On Windows: use `CREATE_NEW_PROCESS_GROUP` for clean process-tree
+   termination
+3. On POSIX: use `start_new_session=True`
+4. Poll `readiness_endpoint` with HTTP GET every
+   `readiness_poll_interval_s` seconds
+5. If the server responds with HTTP < 400: mark as ready, set
+   `_running = True`
+6. If the process exits before becoming ready: raise `GameLoaderError`
+7. If the timeout expires: kill the process and raise `GameLoaderError`
+
+### is_ready()
+
+Sends an HTTP GET to `readiness_endpoint` with a 5-second timeout.
+Returns `True` if the response status is < 400.
+
+### stop()
+
+1. On Windows: `taskkill /F /T /PID <pid>` to kill the whole process tree
+2. On POSIX: `os.killpg()` with `SIGTERM`
+3. Wait up to 10 seconds for graceful shutdown, then force-kill
+4. Set `_running = False`
+
+Safe to call even if the game was never started.
+
+## Breakout71Loader
+
+Thin specialisation of `BrowserGameLoader` with Breakout-71-specific
+defaults.
+
+### Defaults
+
+| Field            | Value                                    |
+|------------------|------------------------------------------|
+| `name`           | `"breakout-71"`                          |
+| `install_command`| `"npm install"`                          |
+| `serve_command`  | `"npx parcel src/index.html --no-cache"` |
+| `serve_port`     | `1234`                                   |
+| `url`            | `"http://localhost:1234"`                |
+| `window_title`   | `"Breakout"`                             |
+
+### Convenience Constructor
+
+```python
+from src.game_loader import Breakout71Loader
+
+loader = Breakout71Loader.from_repo_path(
+    r"F:\work\breakout71-testbed",
+    serve_port=1234,           # optional
+    readiness_timeout_s=120.0, # optional
+    window_title="Breakout",   # optional
+)
+```
+
+### setup() Override
+
+Before calling the parent `setup()`, clears the `.parcel-cache`
+directory if it exists. This prevents stale Parcel caches from
+causing build failures.
+
+## Factory
+
+The `create_loader(config)` factory maps `loader_type` to the
+correct class:
+
+| `loader_type`  | Class               |
+|----------------|---------------------|
+| `"browser"`    | `BrowserGameLoader` |
+| `"breakout-71"`| `Breakout71Loader`  |
+
+### Custom Loader Registration
+
+```python
+from src.game_loader.factory import register_loader
+
+class MyGameLoader(GameLoader):
+    # …
+
+register_loader("my-engine", MyGameLoader)
+```
+
+After registration, `create_loader(config)` will use `MyGameLoader`
+for configs with `loader_type: my-engine`.
+
+## Adding a New Game
+
+1. **Create a YAML config** in `configs/games/<name>.yaml`
+2. Set `loader_type: browser` if the game is a browser game served by
+   a Node dev server — no code needed
+3. If custom logic is required (e.g. emulator startup, native
+   executable), subclass `GameLoader` or `BrowserGameLoader` and
+   register it with `register_loader()`
+
+### Example: Adding a Vite-based Game
+
+```yaml
+# configs/games/my-vite-game.yaml
+name: my-vite-game
+game_dir: /path/to/repo
+loader_type: browser
+install_command: npm install
+serve_command: npx vite --port 5173
+serve_port: 5173
+url: http://localhost:5173
+window_title: My Game
+```
+
+No Python code needed — `BrowserGameLoader` handles Vite the same way
+it handles Parcel.
+
+## Error Handling
+
+| Scenario                     | Behaviour                                          |
+|------------------------------|----------------------------------------------------|
+| `game_dir` does not exist    | `GameLoaderError` raised in `setup()` or `start()` |
+| Install command fails        | `GameLoaderError` with stdout/stderr tail           |
+| Server process exits early   | `GameLoaderError` with exit code and output         |
+| Readiness timeout expires    | Process killed, `GameLoaderError` raised            |
+| Unknown `loader_type`        | `GameLoaderError` from `create_loader()`            |
+| `stop()` before `start()`   | No-op, safe to call                                 |
+
+## Integration with Existing Subsystems
+
+The game loader is the entry point for the QA pipeline.  Once the
+loader reports ready:
+
+- `WindowCapture` can locate the game window via `config.window_title`
+- `InputController` can inject actions into the focused window
+- `Breakout71Env` can be constructed with the known window title and URL
+
+```
+GameLoader.start()
+    │
+    ▼
+WindowCapture(window_title=config.window_title)
+    │
+    ▼
+Breakout71Env / RL agent / oracles
+    │
+    ▼
+GameLoader.stop()
+```
+
+## Source Files
+
+- `src/game_loader/__init__.py` — Package init and public API
+- `src/game_loader/config.py` — `GameLoaderConfig` dataclass and `load_game_config()`
+- `src/game_loader/base.py` — `GameLoader` abstract base class
+- `src/game_loader/browser_loader.py` — `BrowserGameLoader`
+- `src/game_loader/breakout71_loader.py` — `Breakout71Loader`
+- `src/game_loader/factory.py` — `create_loader()` and `register_loader()`
+- `configs/games/breakout-71.yaml` — Breakout 71 configuration
+- `tests/test_game_loader.py` — Test suite (36 tests)

--- a/environment.yml
+++ b/environment.yml
@@ -81,6 +81,8 @@ dependencies:
       # Windows capture / input (platform-specific)
       - pywin32==310
       - pydirectinput==1.0.4
+      # Game loader configuration
+      - pyyaml==6.0.3
       # Templating (for reporting dashboard)
       - jinja2==3.1.6
       # Documentation

--- a/src/game_loader/__init__.py
+++ b/src/game_loader/__init__.py
@@ -1,0 +1,33 @@
+"""Game loader subsystem — launch and manage game processes for QA testing.
+
+Provides a configurable, extensible mechanism for starting games as a
+prerequisite to RL training or automated QA.  Each game is described by
+a :class:`GameLoaderConfig` and managed by a :class:`GameLoader`
+subclass that knows how to build, serve, and health-check it.
+
+Typical usage::
+
+    from src.game_loader import load_game_config, create_loader
+
+    config = load_game_config("breakout-71")
+    loader = create_loader(config)
+    loader.start()          # install deps, launch dev server, wait for ready
+    # … run QA / RL against loader.url …
+    loader.stop()
+"""
+
+from src.game_loader.config import GameLoaderConfig, load_game_config
+from src.game_loader.base import GameLoader, GameLoaderError
+from src.game_loader.browser_loader import BrowserGameLoader
+from src.game_loader.breakout71_loader import Breakout71Loader
+from src.game_loader.factory import create_loader
+
+__all__ = [
+    "GameLoaderConfig",
+    "load_game_config",
+    "GameLoader",
+    "GameLoaderError",
+    "BrowserGameLoader",
+    "Breakout71Loader",
+    "create_loader",
+]

--- a/src/game_loader/base.py
+++ b/src/game_loader/base.py
@@ -1,0 +1,111 @@
+"""Abstract base class for game loaders.
+
+A :class:`GameLoader` manages the full lifecycle of getting a game
+running and reachable so that the QA / RL layer can interact with it.
+
+Subclasses implement the concrete mechanics (e.g. starting a Node dev
+server, launching an emulator, opening a native executable, etc.).
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from typing import Optional
+
+from src.game_loader.config import GameLoaderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class GameLoader(abc.ABC):
+    """Base class for all game loaders.
+
+    The loader lifecycle is:
+
+    1. :meth:`setup`  — one-time preparation (install deps, build, etc.)
+    2. :meth:`start`  — launch the game process and wait until reachable
+    3. :meth:`is_ready` — check if the game is responding
+    4. :meth:`stop`   — tear down the game process and free resources
+
+    Parameters
+    ----------
+    config : GameLoaderConfig
+        Declarative configuration for the game.
+    """
+
+    def __init__(self, config: GameLoaderConfig) -> None:
+        self.config = config
+        self._running: bool = False
+
+    # -- Properties ----------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Human-readable game identifier."""
+        return self.config.name
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL where the running game can be reached, or ``None``."""
+        return self.config.url if self._running else None
+
+    @property
+    def running(self) -> bool:
+        """Whether the game process is currently running."""
+        return self._running
+
+    # -- Lifecycle -----------------------------------------------------
+
+    @abc.abstractmethod
+    def setup(self) -> None:
+        """One-time setup: install dependencies, compile, etc.
+
+        Called before :meth:`start`.  Implementations should be
+        idempotent (safe to call multiple times).
+        """
+
+    @abc.abstractmethod
+    def start(self) -> None:
+        """Launch the game and block until it is ready.
+
+        After this method returns, :attr:`url` must point to a
+        reachable game instance and :attr:`running` must be ``True``.
+
+        Raises
+        ------
+        GameLoaderError
+            If the game fails to start within the configured timeout.
+        """
+
+    @abc.abstractmethod
+    def is_ready(self) -> bool:
+        """Return ``True`` if the game is responding and playable."""
+
+    @abc.abstractmethod
+    def stop(self) -> None:
+        """Shut down the game process and release resources.
+
+        After this method returns, :attr:`running` must be ``False``.
+        Must be safe to call even if the game was never started.
+        """
+
+    # -- Context manager -----------------------------------------------
+
+    def __enter__(self) -> "GameLoader":
+        self.setup()
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # noqa: ANN001
+        self.stop()
+
+    # -- Repr -----------------------------------------------------------
+
+    def __repr__(self) -> str:
+        status = "running" if self._running else "stopped"
+        return f"<{type(self).__name__}({self.config.name!r}, {status})>"
+
+
+class GameLoaderError(Exception):
+    """Raised when a game loader encounters an unrecoverable error."""

--- a/src/game_loader/breakout71_loader.py
+++ b/src/game_loader/breakout71_loader.py
@@ -1,0 +1,100 @@
+"""Breakout 71 game loader — specialisation of :class:`BrowserGameLoader`.
+
+Provides sensible defaults for loading the Breakout 71 browser game
+from a local clone of the repository.  The game uses **Parcel** as its
+bundler and serves on ``http://localhost:1234`` by default.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from src.game_loader.browser_loader import BrowserGameLoader
+from src.game_loader.config import GameLoaderConfig
+
+logger = logging.getLogger(__name__)
+
+# Defaults that match the breakout71-testbed repository layout.
+_DEFAULTS = dict(
+    name="breakout-71",
+    loader_type="breakout-71",
+    install_command="npm install",
+    serve_command="npx parcel src/index.html --no-cache",
+    serve_port=1234,
+    url="http://localhost:1234",
+    readiness_endpoint="http://localhost:1234",
+    readiness_timeout_s=120.0,
+    readiness_poll_interval_s=2.0,
+    window_title="Breakout",
+)
+
+
+class Breakout71Loader(BrowserGameLoader):
+    """Loader tailored for the Breakout 71 browser game.
+
+    Inherits all behaviour from :class:`BrowserGameLoader` and adds:
+
+    - Sensible defaults for Parcel-based serving of Breakout 71.
+    - Convenience constructor :meth:`from_repo_path` that only needs
+      the path to the game repository.
+
+    Parameters
+    ----------
+    config : GameLoaderConfig
+        Full configuration.  Consider using :meth:`from_repo_path`
+        for a simpler API.
+    """
+
+    @classmethod
+    def from_repo_path(
+        cls,
+        game_dir: str | Path,
+        *,
+        serve_port: int = 1234,
+        readiness_timeout_s: float = 120.0,
+        window_title: Optional[str] = None,
+    ) -> "Breakout71Loader":
+        """Create a loader from just the repo path, using defaults.
+
+        Parameters
+        ----------
+        game_dir : str or Path
+            Path to the ``breakout71-testbed`` repository.
+        serve_port : int
+            Port for the Parcel dev server.  Default 1234.
+        readiness_timeout_s : float
+            How long to wait for the server to come up.
+        window_title : str, optional
+            Browser window title override.
+
+        Returns
+        -------
+        Breakout71Loader
+        """
+        url = f"http://localhost:{serve_port}"
+        config = GameLoaderConfig(
+            **{
+                **_DEFAULTS,
+                "game_dir": str(game_dir),
+                "serve_port": serve_port,
+                "url": url,
+                "readiness_endpoint": url,
+                "readiness_timeout_s": readiness_timeout_s,
+                "window_title": window_title or _DEFAULTS["window_title"],
+            }
+        )
+        return cls(config)
+
+    def setup(self) -> None:
+        """Install npm dependencies and clear the Parcel cache."""
+        logger.info("[%s] Clearing .parcel-cache", self.name)
+        cache_dir = self.config.game_dir / ".parcel-cache"
+        if cache_dir.is_dir():
+            import shutil
+
+            shutil.rmtree(cache_dir, ignore_errors=True)
+            logger.info("[%s] Removed %s", self.name, cache_dir)
+
+        super().setup()

--- a/src/game_loader/browser_loader.py
+++ b/src/game_loader/browser_loader.py
@@ -1,0 +1,244 @@
+"""Browser-based game loader — manages Node dev servers for browser games.
+
+Handles the common pattern of: ``npm install`` → ``npx parcel …`` →
+poll ``http://localhost:<port>`` until the dev server responds →
+game is ready for capture / input injection.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from typing import Optional
+
+import urllib.request
+import urllib.error
+
+from src.game_loader.base import GameLoader, GameLoaderError
+from src.game_loader.config import GameLoaderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserGameLoader(GameLoader):
+    """Loader for browser-based games served by a local dev server.
+
+    Manages the lifecycle of a Node.js dev server (e.g. Parcel, Vite,
+    Webpack Dev Server) that serves a browser game.  The general flow:
+
+    1. **setup** — run ``install_command`` (e.g. ``npm install``) in the
+       game's repository directory.
+    2. **start** — spawn ``serve_command`` as a background process, then
+       poll ``readiness_endpoint`` until the server responds with
+       HTTP 200 (or the timeout expires).
+    3. **is_ready** — HTTP GET against the readiness endpoint.
+    4. **stop** — terminate the server subprocess tree.
+
+    Parameters
+    ----------
+    config : GameLoaderConfig
+        Configuration describing the game.  Must include at minimum
+        ``game_dir``, ``serve_command``, and ``serve_port``.
+    """
+
+    def __init__(self, config: GameLoaderConfig) -> None:
+        super().__init__(config)
+        self._process: Optional[subprocess.Popen] = None
+
+    # -- Lifecycle -----------------------------------------------------
+
+    def setup(self) -> None:
+        """Install dependencies via the configured install command.
+
+        Runs ``config.install_command`` (default ``npm install``)
+        inside ``config.game_dir``.  Skipped if ``install_command``
+        is ``None`` or empty.
+        """
+        if not self.config.install_command:
+            logger.info("[%s] No install command configured, skipping setup", self.name)
+            return
+
+        game_dir = self.config.game_dir
+        if not game_dir.is_dir():
+            raise GameLoaderError(f"Game directory does not exist: {game_dir}")
+
+        logger.info(
+            "[%s] Running install: %s (in %s)",
+            self.name,
+            self.config.install_command,
+            game_dir,
+        )
+
+        result = subprocess.run(
+            self.config.install_command,
+            cwd=str(game_dir),
+            shell=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, **self.config.env_vars},
+        )
+        if result.returncode != 0:
+            raise GameLoaderError(
+                f"Install command failed (exit {result.returncode}):\n"
+                f"stdout: {result.stdout[-500:]}\n"
+                f"stderr: {result.stderr[-500:]}"
+            )
+
+        logger.info("[%s] Install completed successfully", self.name)
+
+    def start(self) -> None:
+        """Start the dev server and block until the game is reachable.
+
+        Spawns ``config.serve_command`` as a background subprocess,
+        then polls ``config.readiness_endpoint`` every
+        ``readiness_poll_interval_s`` seconds until it responds with
+        HTTP 200 or ``readiness_timeout_s`` expires.
+
+        Raises
+        ------
+        GameLoaderError
+            If the server process exits unexpectedly or the readiness
+            timeout expires.
+        """
+        if self._running:
+            logger.warning("[%s] Already running, stop first", self.name)
+            return
+
+        game_dir = self.config.game_dir
+        if not game_dir.is_dir():
+            raise GameLoaderError(f"Game directory does not exist: {game_dir}")
+
+        logger.info(
+            "[%s] Starting dev server: %s (in %s)",
+            self.name,
+            self.config.serve_command,
+            game_dir,
+        )
+
+        # Use CREATE_NEW_PROCESS_GROUP on Windows so we can terminate
+        # the whole tree; on POSIX use start_new_session.
+        kwargs: dict = dict(
+            cwd=str(game_dir),
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, **self.config.env_vars},
+        )
+        if sys.platform == "win32":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            kwargs["start_new_session"] = True
+
+        self._process = subprocess.Popen(self.config.serve_command, **kwargs)
+        logger.info("[%s] Server process PID: %d", self.name, self._process.pid)
+
+        # Poll readiness
+        self._wait_until_ready()
+        self._running = True
+        logger.info("[%s] Game is ready at %s", self.name, self.config.url)
+
+    def is_ready(self) -> bool:
+        """Check if the dev server is responding to HTTP requests.
+
+        Returns
+        -------
+        bool
+            ``True`` if an HTTP GET to the readiness endpoint returns
+            a status code < 400.
+        """
+        try:
+            req = urllib.request.Request(
+                self.config.readiness_endpoint,
+                method="GET",
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                return resp.status < 400
+        except (urllib.error.URLError, OSError, ValueError):
+            return False
+
+    def stop(self) -> None:
+        """Terminate the dev server process and clean up.
+
+        On Windows, sends ``CTRL_BREAK_EVENT`` to the process group.
+        On POSIX, sends ``SIGTERM`` to the process group.
+        """
+        if self._process is None:
+            self._running = False
+            return
+
+        pid = self._process.pid
+        logger.info("[%s] Stopping server (PID %d)", self.name, pid)
+
+        try:
+            if sys.platform == "win32":
+                # Kill the whole process tree on Windows
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/PID", str(pid)],
+                    capture_output=True,
+                )
+            else:
+                os.killpg(os.getpgid(pid), signal.SIGTERM)
+
+            self._process.wait(timeout=10)
+        except (ProcessLookupError, OSError, subprocess.TimeoutExpired):
+            logger.warning("[%s] Forceful termination of PID %d", self.name, pid)
+            try:
+                self._process.kill()
+                self._process.wait(timeout=5)
+            except Exception:
+                pass
+
+        self._process = None
+        self._running = False
+        logger.info("[%s] Server stopped", self.name)
+
+    # -- Internal -------------------------------------------------------
+
+    def _wait_until_ready(self) -> None:
+        """Poll the readiness endpoint until it responds or timeout.
+
+        Raises
+        ------
+        GameLoaderError
+            If the server process exits or the timeout expires before
+            the endpoint responds.
+        """
+        deadline = time.monotonic() + self.config.readiness_timeout_s
+        interval = self.config.readiness_poll_interval_s
+        endpoint = self.config.readiness_endpoint
+
+        logger.info(
+            "[%s] Waiting for %s (timeout %.0fs)",
+            self.name,
+            endpoint,
+            self.config.readiness_timeout_s,
+        )
+
+        while time.monotonic() < deadline:
+            # Check if process died
+            if self._process is not None and self._process.poll() is not None:
+                stdout = self._process.stdout.read() if self._process.stdout else ""
+                stderr = self._process.stderr.read() if self._process.stderr else ""
+                raise GameLoaderError(
+                    f"Server process exited with code "
+                    f"{self._process.returncode} before becoming ready.\n"
+                    f"stdout: {stdout[-500:]}\n"
+                    f"stderr: {stderr[-500:]}"
+                )
+
+            if self.is_ready():
+                return
+
+            time.sleep(interval)
+
+        # Timeout — kill the process so we don't leak it
+        self.stop()
+        raise GameLoaderError(
+            f"Server did not become ready within "
+            f"{self.config.readiness_timeout_s}s at {endpoint}"
+        )

--- a/src/game_loader/config.py
+++ b/src/game_loader/config.py
@@ -1,0 +1,124 @@
+"""Game loader configuration data structures.
+
+A :class:`GameLoaderConfig` describes everything the loader needs to
+know about a game: where its source lives, how to install dependencies,
+how to serve it, and how to tell when it is ready.
+
+Configs can be loaded from YAML files via :func:`load_game_config`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Default search path for game config YAML files.
+_CONFIGS_DIR = Path(__file__).resolve().parent.parent.parent / "configs" / "games"
+
+
+@dataclass
+class GameLoaderConfig:
+    """Declarative description of how to load a game for QA.
+
+    Parameters
+    ----------
+    name : str
+        Human-readable identifier for the game (e.g. ``"breakout-71"``).
+    game_dir : str or Path
+        Absolute or relative path to the game's source repository.
+    loader_type : str
+        Which :class:`GameLoader` subclass to use.  Built-in values:
+        ``"browser"`` and ``"breakout-71"``.
+    install_command : str, optional
+        Shell command to install dependencies (e.g. ``"npm install"``).
+        Run once during :meth:`GameLoader.setup`.
+    serve_command : str
+        Shell command to start the game's dev server.
+    serve_port : int
+        Port the dev server listens on.
+    url : str
+        Full URL the game is reachable at once the server is up.
+    readiness_endpoint : str
+        URL to poll (HTTP GET) to determine when the server is ready.
+        Defaults to the same value as ``url``.
+    readiness_timeout_s : float
+        Maximum seconds to wait for the readiness endpoint to respond.
+    readiness_poll_interval_s : float
+        Seconds between readiness polls.
+    window_title : str, optional
+        Expected browser window/tab title once the game is loaded.
+        Used by ``WindowCapture`` to locate the game surface.
+    env_vars : dict[str, str]
+        Extra environment variables to set for the serve process.
+    """
+
+    name: str
+    game_dir: str | Path
+    loader_type: str = "browser"
+
+    # Build / serve
+    install_command: Optional[str] = "npm install"
+    serve_command: str = "npx parcel src/index.html --no-cache"
+    serve_port: int = 1234
+    url: str = "http://localhost:1234"
+    readiness_endpoint: str = ""
+    readiness_timeout_s: float = 120.0
+    readiness_poll_interval_s: float = 2.0
+
+    # Window identification (for capture layer)
+    window_title: Optional[str] = None
+
+    # Extra env for the serve process
+    env_vars: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.game_dir = Path(self.game_dir)
+        if not self.readiness_endpoint:
+            self.readiness_endpoint = self.url
+
+
+def load_game_config(
+    name: str,
+    configs_dir: str | Path | None = None,
+) -> GameLoaderConfig:
+    """Load a :class:`GameLoaderConfig` from a YAML file.
+
+    Searches ``configs_dir`` (default ``configs/games/``) for a file
+    named ``<name>.yaml``.
+
+    Parameters
+    ----------
+    name : str
+        Game identifier matching the YAML filename (without extension).
+    configs_dir : str or Path, optional
+        Override the default config directory.
+
+    Returns
+    -------
+    GameLoaderConfig
+
+    Raises
+    ------
+    FileNotFoundError
+        If no YAML file is found for ``name``.
+    """
+    search_dir = Path(configs_dir) if configs_dir else _CONFIGS_DIR
+    config_path = search_dir / f"{name}.yaml"
+
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"No game config found at {config_path}. "
+            f"Available configs: {[p.stem for p in search_dir.glob('*.yaml')]}"
+        )
+
+    logger.info("Loading game config from %s", config_path)
+    with open(config_path, "r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+
+    return GameLoaderConfig(**raw)

--- a/src/game_loader/factory.py
+++ b/src/game_loader/factory.py
@@ -1,0 +1,82 @@
+"""Factory function for creating game loaders from configuration.
+
+The :func:`create_loader` function maps a :class:`GameLoaderConfig`
+to the appropriate :class:`GameLoader` subclass based on the
+``loader_type`` field.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.game_loader.base import GameLoader, GameLoaderError
+from src.game_loader.config import GameLoaderConfig
+
+logger = logging.getLogger(__name__)
+
+# Registry of loader_type → class.  Kept flat and simple; games that
+# need truly custom loaders can register themselves here.
+_LOADER_REGISTRY: dict[str, type[GameLoader]] = {}
+
+
+def _ensure_registry() -> None:
+    """Lazily populate the registry to avoid circular imports."""
+    if _LOADER_REGISTRY:
+        return
+
+    from src.game_loader.browser_loader import BrowserGameLoader
+    from src.game_loader.breakout71_loader import Breakout71Loader
+
+    _LOADER_REGISTRY["browser"] = BrowserGameLoader
+    _LOADER_REGISTRY["breakout-71"] = Breakout71Loader
+
+
+def create_loader(config: GameLoaderConfig) -> GameLoader:
+    """Instantiate the correct :class:`GameLoader` for ``config``.
+
+    Parameters
+    ----------
+    config : GameLoaderConfig
+        Game configuration.  The ``loader_type`` field selects which
+        loader class to use.
+
+    Returns
+    -------
+    GameLoader
+        A fully-constructed (but not yet started) loader instance.
+
+    Raises
+    ------
+    GameLoaderError
+        If ``loader_type`` is not recognised.
+    """
+    _ensure_registry()
+
+    loader_cls = _LOADER_REGISTRY.get(config.loader_type)
+    if loader_cls is None:
+        raise GameLoaderError(
+            f"Unknown loader_type {config.loader_type!r}. "
+            f"Available: {sorted(_LOADER_REGISTRY)}"
+        )
+
+    logger.info(
+        "Creating %s for game %r",
+        loader_cls.__name__,
+        config.name,
+    )
+    return loader_cls(config)
+
+
+def register_loader(name: str, loader_cls: type[GameLoader]) -> None:
+    """Register a custom loader class for a given ``loader_type``.
+
+    Parameters
+    ----------
+    name : str
+        The ``loader_type`` value that should map to ``loader_cls``.
+    loader_cls : type[GameLoader]
+        The loader class.
+    """
+    _ensure_registry()
+    _LOADER_REGISTRY[name] = loader_cls
+    logger.info("Registered custom loader %r → %s", name, loader_cls.__name__)

--- a/tests/test_game_loader.py
+++ b/tests/test_game_loader.py
@@ -1,0 +1,451 @@
+"""Tests for the game_loader subsystem.
+
+Tests cover:
+
+- GameLoaderConfig construction and defaults
+- YAML config loading (load_game_config)
+- GameLoader ABC contract
+- BrowserGameLoader lifecycle (with mocked subprocess/HTTP)
+- Breakout71Loader defaults and cache clearing
+- Factory (create_loader) dispatch
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.game_loader.base import GameLoader, GameLoaderError
+from src.game_loader.browser_loader import BrowserGameLoader
+from src.game_loader.breakout71_loader import Breakout71Loader
+from src.game_loader.config import GameLoaderConfig, load_game_config
+from src.game_loader.factory import create_loader, register_loader
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _make_config(**overrides) -> GameLoaderConfig:
+    """Build a minimal GameLoaderConfig with sensible test defaults."""
+    defaults = dict(
+        name="test-game",
+        game_dir=".",
+        loader_type="browser",
+        install_command=None,
+        serve_command="echo serving",
+        serve_port=9999,
+        url="http://localhost:9999",
+    )
+    defaults.update(overrides)
+    return GameLoaderConfig(**defaults)
+
+
+# ── GameLoaderConfig ────────────────────────────────────────────────
+
+
+class TestGameLoaderConfig:
+    """Tests for the configuration dataclass."""
+
+    def test_minimal_construction(self):
+        """Config can be built with just name and game_dir."""
+        cfg = GameLoaderConfig(name="foo", game_dir="/tmp/foo")
+        assert cfg.name == "foo"
+        assert cfg.game_dir == Path("/tmp/foo")
+        assert cfg.loader_type == "browser"
+
+    def test_defaults(self):
+        """Default values are applied correctly."""
+        cfg = GameLoaderConfig(name="foo", game_dir=".")
+        assert cfg.serve_port == 1234
+        assert cfg.readiness_timeout_s == 120.0
+        assert cfg.readiness_poll_interval_s == 2.0
+        assert cfg.install_command == "npm install"
+
+    def test_readiness_endpoint_defaults_to_url(self):
+        """If readiness_endpoint is empty, it falls back to url."""
+        cfg = GameLoaderConfig(name="foo", game_dir=".", url="http://localhost:5000")
+        assert cfg.readiness_endpoint == "http://localhost:5000"
+
+    def test_readiness_endpoint_override(self):
+        """Explicit readiness_endpoint is preserved."""
+        cfg = GameLoaderConfig(
+            name="foo",
+            game_dir=".",
+            url="http://localhost:5000",
+            readiness_endpoint="http://localhost:5000/health",
+        )
+        assert cfg.readiness_endpoint == "http://localhost:5000/health"
+
+    def test_game_dir_converted_to_path(self):
+        """game_dir string is converted to a Path."""
+        cfg = GameLoaderConfig(name="foo", game_dir="/some/path")
+        assert isinstance(cfg.game_dir, Path)
+        assert cfg.game_dir == Path("/some/path")
+
+    def test_env_vars_default_empty(self):
+        """env_vars defaults to an empty dict."""
+        cfg = GameLoaderConfig(name="foo", game_dir=".")
+        assert cfg.env_vars == {}
+
+    def test_custom_env_vars(self):
+        """Custom env_vars are stored correctly."""
+        cfg = GameLoaderConfig(name="foo", game_dir=".", env_vars={"NODE_ENV": "test"})
+        assert cfg.env_vars == {"NODE_ENV": "test"}
+
+
+# ── YAML loading ────────────────────────────────────────────────────
+
+
+class TestLoadGameConfig:
+    """Tests for load_game_config YAML parsing."""
+
+    def test_load_from_yaml(self, tmp_path: Path):
+        """A valid YAML file produces a correct GameLoaderConfig."""
+        yaml_content = textwrap.dedent("""\
+            name: my-game
+            game_dir: /opt/games/my-game
+            loader_type: browser
+            serve_command: npm run dev
+            serve_port: 3000
+            url: http://localhost:3000
+            readiness_timeout_s: 60.0
+        """)
+        config_file = tmp_path / "my-game.yaml"
+        config_file.write_text(yaml_content, encoding="utf-8")
+
+        cfg = load_game_config("my-game", configs_dir=tmp_path)
+        assert cfg.name == "my-game"
+        assert cfg.serve_port == 3000
+        assert cfg.readiness_timeout_s == 60.0
+        assert cfg.loader_type == "browser"
+
+    def test_missing_config_raises(self, tmp_path: Path):
+        """FileNotFoundError is raised for a missing config."""
+        with pytest.raises(FileNotFoundError, match="no-such-game"):
+            load_game_config("no-such-game", configs_dir=tmp_path)
+
+    def test_load_breakout71_config(self):
+        """The shipped breakout-71.yaml config loads successfully."""
+        configs_dir = Path(__file__).resolve().parent.parent / "configs" / "games"
+        if not (configs_dir / "breakout-71.yaml").exists():
+            pytest.skip("breakout-71.yaml not found in configs/games/")
+
+        cfg = load_game_config("breakout-71", configs_dir=configs_dir)
+        assert cfg.name == "breakout-71"
+        assert cfg.loader_type == "breakout-71"
+        assert cfg.serve_port == 1234
+
+
+# ── GameLoader ABC ──────────────────────────────────────────────────
+
+
+class TestGameLoaderABC:
+    """Tests for the abstract base class contract."""
+
+    def test_cannot_instantiate_directly(self):
+        """GameLoader cannot be instantiated (it is abstract)."""
+        cfg = _make_config()
+        with pytest.raises(TypeError):
+            GameLoader(cfg)  # type: ignore[abstract]
+
+    def test_repr_stopped(self):
+        """repr shows 'stopped' when not running."""
+        cfg = _make_config()
+        loader = BrowserGameLoader(cfg)
+        assert "stopped" in repr(loader)
+        assert "test-game" in repr(loader)
+
+    def test_url_is_none_when_stopped(self):
+        """url property returns None when the loader is not running."""
+        cfg = _make_config()
+        loader = BrowserGameLoader(cfg)
+        assert loader.url is None
+
+    def test_running_is_false_initially(self):
+        """running is False right after construction."""
+        cfg = _make_config()
+        loader = BrowserGameLoader(cfg)
+        assert loader.running is False
+
+
+# ── BrowserGameLoader ───────────────────────────────────────────────
+
+
+class TestBrowserGameLoader:
+    """Tests for the browser-based game loader."""
+
+    def test_construction(self):
+        """BrowserGameLoader can be constructed with a config."""
+        cfg = _make_config()
+        loader = BrowserGameLoader(cfg)
+        assert loader.name == "test-game"
+        assert not loader.running
+
+    def test_setup_skips_when_no_install_command(self):
+        """setup() does nothing when install_command is None."""
+        cfg = _make_config(install_command=None)
+        loader = BrowserGameLoader(cfg)
+        # Should not raise
+        loader.setup()
+
+    def test_setup_raises_on_missing_dir(self, tmp_path: Path):
+        """setup() raises GameLoaderError if game_dir doesn't exist."""
+        cfg = _make_config(
+            game_dir=str(tmp_path / "nonexistent"),
+            install_command="npm install",
+        )
+        loader = BrowserGameLoader(cfg)
+        with pytest.raises(GameLoaderError, match="does not exist"):
+            loader.setup()
+
+    @mock.patch("subprocess.run")
+    def test_setup_runs_install_command(self, mock_run, tmp_path: Path):
+        """setup() executes the install command in game_dir."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args="npm install", returncode=0, stdout="", stderr=""
+        )
+        cfg = _make_config(
+            game_dir=str(tmp_path),
+            install_command="npm install",
+        )
+        loader = BrowserGameLoader(cfg)
+        loader.setup()
+
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args
+        assert call_kwargs[0][0] == "npm install"
+        assert call_kwargs[1]["cwd"] == str(tmp_path)
+
+    @mock.patch("subprocess.run")
+    def test_setup_raises_on_install_failure(self, mock_run, tmp_path: Path):
+        """setup() raises GameLoaderError if install command fails."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args="npm install", returncode=1, stdout="", stderr="ERR!"
+        )
+        cfg = _make_config(
+            game_dir=str(tmp_path),
+            install_command="npm install",
+        )
+        loader = BrowserGameLoader(cfg)
+        with pytest.raises(GameLoaderError, match="Install command failed"):
+            loader.setup()
+
+    def test_is_ready_returns_false_when_nothing_running(self):
+        """is_ready() returns False when no server is running."""
+        cfg = _make_config()
+        loader = BrowserGameLoader(cfg)
+        assert loader.is_ready() is False
+
+    def test_stop_is_safe_when_not_started(self):
+        """stop() does not raise when called before start()."""
+        cfg = _make_config()
+        loader = BrowserGameLoader(cfg)
+        loader.stop()
+        assert not loader.running
+
+    @mock.patch("subprocess.Popen")
+    @mock.patch.object(BrowserGameLoader, "is_ready", return_value=True)
+    def test_start_launches_process(self, mock_ready, mock_popen, tmp_path: Path):
+        """start() spawns a subprocess and sets running=True."""
+        mock_proc = mock.MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        cfg = _make_config(game_dir=str(tmp_path))
+        loader = BrowserGameLoader(cfg)
+        loader.start()
+
+        assert loader.running is True
+        assert loader.url == "http://localhost:9999"
+        mock_popen.assert_called_once()
+
+    @mock.patch("subprocess.Popen")
+    @mock.patch.object(BrowserGameLoader, "is_ready", return_value=True)
+    def test_start_then_stop(self, mock_ready, mock_popen, tmp_path: Path):
+        """Full start→stop lifecycle completes cleanly."""
+        mock_proc = mock.MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        cfg = _make_config(game_dir=str(tmp_path))
+        loader = BrowserGameLoader(cfg)
+        loader.start()
+        assert loader.running
+
+        with mock.patch("subprocess.run"):  # mock taskkill
+            loader.stop()
+        assert not loader.running
+        assert loader.url is None
+
+    @mock.patch("subprocess.Popen")
+    @mock.patch.object(BrowserGameLoader, "is_ready", return_value=True)
+    def test_context_manager(self, mock_ready, mock_popen, tmp_path: Path):
+        """GameLoader works as a context manager."""
+        mock_proc = mock.MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        cfg = _make_config(game_dir=str(tmp_path), install_command=None)
+
+        with mock.patch("subprocess.run"):
+            with BrowserGameLoader(cfg) as loader:
+                assert loader.running
+            assert not loader.running
+
+    @mock.patch("subprocess.Popen")
+    def test_start_raises_on_process_exit(self, mock_popen, tmp_path: Path):
+        """start() raises if the server process exits immediately."""
+        mock_proc = mock.MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = 1  # exited immediately
+        mock_proc.returncode = 1
+        mock_proc.stdout.read.return_value = ""
+        mock_proc.stderr.read.return_value = "crash"
+        mock_popen.return_value = mock_proc
+
+        cfg = _make_config(
+            game_dir=str(tmp_path),
+            readiness_timeout_s=2.0,
+            readiness_poll_interval_s=0.1,
+        )
+        loader = BrowserGameLoader(cfg)
+        with pytest.raises(GameLoaderError, match="exited with code"):
+            loader.start()
+
+    @mock.patch("subprocess.Popen")
+    @mock.patch.object(BrowserGameLoader, "is_ready", return_value=False)
+    def test_start_raises_on_timeout(self, mock_ready, mock_popen, tmp_path: Path):
+        """start() raises if readiness endpoint never responds."""
+        mock_proc = mock.MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        cfg = _make_config(
+            game_dir=str(tmp_path),
+            readiness_timeout_s=0.5,
+            readiness_poll_interval_s=0.1,
+        )
+        loader = BrowserGameLoader(cfg)
+        with mock.patch("subprocess.run"):  # mock taskkill in stop()
+            with pytest.raises(GameLoaderError, match="did not become ready"):
+                loader.start()
+
+
+# ── Breakout71Loader ────────────────────────────────────────────────
+
+
+class TestBreakout71Loader:
+    """Tests for the Breakout 71 specialisation."""
+
+    def test_from_repo_path(self, tmp_path: Path):
+        """from_repo_path creates a loader with correct defaults."""
+        loader = Breakout71Loader.from_repo_path(tmp_path)
+        assert loader.name == "breakout-71"
+        assert loader.config.serve_port == 1234
+        assert loader.config.game_dir == tmp_path
+        assert "parcel" in loader.config.serve_command
+
+    def test_from_repo_path_custom_port(self, tmp_path: Path):
+        """from_repo_path respects a custom port."""
+        loader = Breakout71Loader.from_repo_path(tmp_path, serve_port=3000)
+        assert loader.config.serve_port == 3000
+        assert "3000" in loader.config.url
+
+    def test_setup_clears_parcel_cache(self, tmp_path: Path):
+        """setup() removes .parcel-cache before installing."""
+        cache_dir = tmp_path / ".parcel-cache"
+        cache_dir.mkdir()
+        (cache_dir / "dummy").write_text("x")
+
+        loader = Breakout71Loader.from_repo_path(tmp_path)
+        # Patch the parent setup to avoid actually running npm install
+        with mock.patch.object(BrowserGameLoader, "setup"):
+            loader.setup()
+
+        assert not cache_dir.exists()
+
+    def test_setup_works_without_cache_dir(self, tmp_path: Path):
+        """setup() succeeds even if .parcel-cache doesn't exist."""
+        loader = Breakout71Loader.from_repo_path(tmp_path)
+        with mock.patch.object(BrowserGameLoader, "setup"):
+            loader.setup()  # should not raise
+
+    def test_window_title_default(self, tmp_path: Path):
+        """Default window_title is set for Breakout."""
+        loader = Breakout71Loader.from_repo_path(tmp_path)
+        assert loader.config.window_title == "Breakout"
+
+
+# ── Factory ─────────────────────────────────────────────────────────
+
+
+class TestFactory:
+    """Tests for the create_loader factory function."""
+
+    def test_create_browser_loader(self):
+        """loader_type='browser' creates a BrowserGameLoader."""
+        cfg = _make_config(loader_type="browser")
+        loader = create_loader(cfg)
+        assert isinstance(loader, BrowserGameLoader)
+
+    def test_create_breakout71_loader(self, tmp_path: Path):
+        """loader_type='breakout-71' creates a Breakout71Loader."""
+        cfg = _make_config(
+            loader_type="breakout-71",
+            game_dir=str(tmp_path),
+        )
+        loader = create_loader(cfg)
+        assert isinstance(loader, Breakout71Loader)
+
+    def test_unknown_loader_type_raises(self):
+        """Unknown loader_type raises GameLoaderError."""
+        cfg = _make_config(loader_type="alien-game-engine")
+        with pytest.raises(GameLoaderError, match="Unknown loader_type"):
+            create_loader(cfg)
+
+    def test_register_custom_loader(self):
+        """register_loader adds a custom loader type."""
+
+        class DummyLoader(GameLoader):
+            def setup(self):
+                pass
+
+            def start(self):
+                pass
+
+            def is_ready(self):
+                return True
+
+            def stop(self):
+                pass
+
+        register_loader("dummy", DummyLoader)
+        cfg = _make_config(loader_type="dummy")
+        loader = create_loader(cfg)
+        assert isinstance(loader, DummyLoader)
+
+    def test_end_to_end_yaml_to_loader(self, tmp_path: Path):
+        """Full flow: YAML file → load_game_config → create_loader."""
+        yaml_content = textwrap.dedent("""\
+            name: e2e-game
+            game_dir: .
+            loader_type: browser
+            serve_command: echo hi
+            serve_port: 8080
+            url: http://localhost:8080
+        """)
+        config_file = tmp_path / "e2e-game.yaml"
+        config_file.write_text(yaml_content, encoding="utf-8")
+
+        cfg = load_game_config("e2e-game", configs_dir=tmp_path)
+        loader = create_loader(cfg)
+        assert isinstance(loader, BrowserGameLoader)
+        assert loader.name == "e2e-game"


### PR DESCRIPTION
## Summary

Adds a new `game_loader` subsystem that manages the full lifecycle of getting a game running and reachable before QA testing or RL training can begin. Games are configured declaratively via YAML, and the class hierarchy is extensible to support different game types.

- **GameLoaderConfig** dataclass with YAML loading (`load_game_config()`) for declarative game descriptions
- **GameLoader** abstract base class defining the setup/start/is_ready/stop lifecycle (with context manager support)
- **BrowserGameLoader** for Node dev server games (subprocess management, HTTP readiness polling, cross-platform process termination)
- **Breakout71Loader** specialization with Parcel-specific defaults and cache clearing
- **Factory** (`create_loader()`, `register_loader()`) with a loader type registry for extensibility
- **36 new tests** (66 total, all passing) covering config, YAML loading, ABC contract, lifecycle, factory dispatch
- **Full documentation**: design spec, Sphinx API docs, README updates

## Motivation

The QA platform needs a reliable, repeatable way to start up the game-under-test before any capture, input injection, or RL training can begin. This was previously a manual step. The game loader makes it automated and configurable — drop a YAML file in `configs/games/` to add a new browser game with zero Python code.

## Key Design Decisions

- **YAML-driven config** over Python-only config — allows non-developers to add new games, keeps game definitions version-controlled and diff-friendly
- **Class hierarchy** (`GameLoader` → `BrowserGameLoader` → `Breakout71Loader`) rather than a monolithic class — makes it easy to add emulator-based or native game loaders later
- **Lazy registry** in the factory avoids circular imports while keeping the API simple
- **Cross-platform process management** — `CREATE_NEW_PROCESS_GROUP` + `taskkill /T` on Windows, `start_new_session` + `os.killpg` on POSIX

## Files Changed

### New
- `src/game_loader/` — Full package (config, base, browser_loader, breakout71_loader, factory, __init__)
- `configs/games/breakout-71.yaml` — Breakout 71 game configuration
- `tests/test_game_loader.py` — 36 tests
- `documentation/specs/game_loader_spec.md` — Design specification
- `docs/specs/game_loader.md` — Sphinx spec include
- `docs/api/game_loader.rst` — API reference autodoc

### Modified
- `README.md` — Architecture diagram, project structure, usage docs, test count
- `docs/api/index.rst` — Added game_loader to API toctree
- `docs/specs/index.md` — Added game_loader to specs toctree
- `docs/conf.py` — Added `yaml` to autodoc_mock_imports
- `environment.yml` — Added `pyyaml==6.0.3`

## Testing

All 66 tests pass. Tests use mocked subprocess/HTTP to avoid requiring a real game installation. CI pipeline (Lint, Test, Build Check, Build Docs) passes.