### PR TITLE
fix: resolve game loader code review improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 World Model V1.v1-roboflow-instant-1--eval-.yolov8.zip
 index.html
-.vscode/settings.json
+.vscode/
 scripts/VLC_SFF.exe
 runs/*
 */runs/*

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ src/
 configs/
   games/                Game loader YAML configs (breakout-71.yaml, ...)
 scripts/                YOLO training, dataset dedup, ADB test
-tests/                  pytest suite (66 tests)
+tests/                  pytest suite (82 tests)
 docs/                   Sphinx docs (Furo theme, MyST Markdown)
 documentation/
   specs/                Design specs for env, oracles, capture, reporting, game loader
@@ -141,7 +141,7 @@ GitHub Actions runs on every push to `main` or `big-rock-*` branches and on PRs 
 | Job | What it does |
 |-----|-------------|
 | **Lint** | `ruff check` + `ruff format --check` |
-| **Test** | `pytest` (66 passed) |
+| **Test** | `pytest` (82 passed) |
 | **Build Check** | Verifies all module imports succeed |
 | **Build Docs** | Sphinx HTML build with `-W` (warnings as errors) |
 

--- a/configs/games/breakout-71.yaml
+++ b/configs/games/breakout-71.yaml
@@ -9,9 +9,14 @@
 #   config = load_game_config("breakout-71")
 #   loader = create_loader(config)
 #   loader.start()
+#
+# Note: game_dir supports environment variable expansion ($VAR or
+# ${VAR}) and ~ for home directory.  Set BREAKOUT71_DIR in your
+# environment to override the default path, e.g.:
+#   export BREAKOUT71_DIR=/home/user/breakout71-testbed
 
 name: breakout-71
-game_dir: F:\work\breakout71-testbed
+game_dir: ${BREAKOUT71_DIR:-F:\work\breakout71-testbed}
 loader_type: breakout-71
 
 # -- Build / serve -----------------------------------------------------

--- a/src/game_loader/base.py
+++ b/src/game_loader/base.py
@@ -97,8 +97,9 @@ class GameLoader(abc.ABC):
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # noqa: ANN001
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:  # noqa: ANN001
         self.stop()
+        return False
 
     # -- Repr -----------------------------------------------------------
 

--- a/src/game_loader/breakout71_loader.py
+++ b/src/game_loader/breakout71_loader.py
@@ -8,6 +8,7 @@ bundler and serves on ``http://localhost:1234`` by default.
 from __future__ import annotations
 
 import logging
+import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -92,8 +93,6 @@ class Breakout71Loader(BrowserGameLoader):
         logger.info("[%s] Clearing .parcel-cache", self.name)
         cache_dir = self.config.game_dir / ".parcel-cache"
         if cache_dir.is_dir():
-            import shutil
-
             shutil.rmtree(cache_dir, ignore_errors=True)
             logger.info("[%s] Removed %s", self.name, cache_dir)
 

--- a/src/game_loader/factory.py
+++ b/src/game_loader/factory.py
@@ -17,18 +17,21 @@ logger = logging.getLogger(__name__)
 # Registry of loader_type → class.  Kept flat and simple; games that
 # need truly custom loaders can register themselves here.
 _LOADER_REGISTRY: dict[str, type[GameLoader]] = {}
+_REGISTRY_INITIALIZED: bool = False
 
 
 def _ensure_registry() -> None:
     """Lazily populate the registry to avoid circular imports."""
-    if _LOADER_REGISTRY:
+    global _REGISTRY_INITIALIZED  # noqa: PLW0603
+    if _REGISTRY_INITIALIZED:
         return
 
     from src.game_loader.browser_loader import BrowserGameLoader
     from src.game_loader.breakout71_loader import Breakout71Loader
 
-    _LOADER_REGISTRY["browser"] = BrowserGameLoader
-    _LOADER_REGISTRY["breakout-71"] = Breakout71Loader
+    _LOADER_REGISTRY.setdefault("browser", BrowserGameLoader)
+    _LOADER_REGISTRY.setdefault("breakout-71", Breakout71Loader)
+    _REGISTRY_INITIALIZED = True
 
 
 def create_loader(config: GameLoaderConfig) -> GameLoader:


### PR DESCRIPTION
## Summary

Resolves all 7 code review items from PR #4 plus a .gitignore improvement.

Closes #5

## Changes

1. **Hardened `_ensure_registry()`** — Replaced dict-emptiness guard with `_REGISTRY_INITIALIZED` sentinel flag; uses `setdefault` so custom registrations aren't overwritten by the built-in re-registration
2. **Fixed `stop()` docstring** — Now documents `taskkill /F /T` instead of `CTRL_BREAK_EVENT` (matching the actual implementation)
3. **Environment variable expansion** — Added `_expand_vars()` supporting `$VAR`, `${VAR}`, and `${VAR:-default}` syntax; `_expand_vars_recursive()` for nested YAML dicts; `__post_init__` runs `os.path.expanduser()` + `_expand_vars()` on `game_dir`; updated `breakout-71.yaml` to use `${BREAKOUT71_DIR:-F:\work\breakout71-testbed}`
4. **Moved `shutil` import to module level** in `breakout71_loader.py`
5. **YAML config validation** — `load_game_config` now validates unknown fields with helpful error messages listing valid field names; catches non-mapping YAML
6. **TCP socket probe** — `is_ready()` now does two-stage check: `_tcp_probe()` (socket connect) then HTTP GET; added `_tcp_probe()` method using `socket.create_connection`
7. **Explicit `return False` from `__exit__`** — return type changed to `bool`
8. **`.gitignore`** — `.vscode/` replaces `.vscode/settings.json`
9. **README** — Updated test count from 66 → 82

## Testing

- 82 tests pass (16 new: 8 env var expansion, 4 config validation, 3 TCP probe, 1 `__exit__`)
- All CI jobs pass: Lint, Test, Build Check, Build Docs