### PR TITLE
docs: update reporting spec and README to reflect implemented subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ src/
   oracles/              Bug-detection oracles (crash, stuck, score, visual, perf) [stub on_step]
   perception/           YOLO detector wrapper [stub]
   policies/             YOLO-based + RL-based policies for Last War
-  reporting/            Episode/session reports + Jinja2 dashboard [stub]
+  reporting/            Episode/session reports + Jinja2 HTML dashboard
   rl/                   RL training env + PPO training script for help policy
 configs/
   games/                Game loader YAML configs (breakout-71.yaml, ...)


### PR DESCRIPTION
## Summary
- Updated `documentation/specs/reporting_system_spec.md` to reflect the actual implemented reporting subsystem (severity naming convention `critical/warning/info`, built-in Bootstrap 5 template, `build_id` from env var, `seed` field on `EpisodeReport`)
- Updated `README.md` to remove `[stub]` label from reporting subsystem entry

## Changes
- **reporting_system_spec.md**: Aligned spec with implementation — 346 lines changed to match actual dataclass fields, severity conventions, `DashboardRenderer` built-in template, and `ReportGenerator` API
- **README.md**: Reporting line updated from `[stub]` to reflect completed status