### PR TITLE
docs: add technical intake workflow and business proposition

### DIFF
--- a/documentation/business/business_proposition.md
+++ b/documentation/business/business_proposition.md
@@ -1,0 +1,206 @@
+# Business Proposition: Pixel-Based Game QA
+
+Rough draft -- hours-based, pre-revenue. Pricing TBD based on investor
+expectations and customer willingness to pay.
+
+## The Pitch
+
+**"We play your game 24/7 and find bugs you can't."**
+
+RSN Game QA deploys AI agents that play your game from pixels -- no source
+code access needed, no SDK integration. Our agents learn to play, and 12
+specialized oracles watch every frame for crashes, stuck states, physics
+violations, visual glitches, score anomalies, and balance issues. You get
+an HTML dashboard with timestamped findings and replay-ready frame
+sequences.
+
+## Why Pixel-Based Is the Moat
+
+The core architectural decision: **pixels in, mouse/keyboard out**. This
+is not a limitation -- it is the product.
+
+1. **No integration burden on the client.** They don't ship source code,
+   don't add SDK hooks, don't modify their build. We just need the game
+   running in a window.
+
+2. **Works across engines.** Unity, Unreal, Godot, custom HTML5, native
+   Win32, mobile via emulator -- all the same to us. We see pixels.
+
+3. **Tests the real player experience.** If a bug is invisible to the
+   player (internal state inconsistency that never manifests visually), we
+   don't flag it. If it's visible, we catch it. This matches what players
+   actually report.
+
+4. **Scales to games we can't read.** Obfuscated code, closed-source
+   engines, mobile games via emulator -- all fair game.
+
+5. **Honest testing.** We have no privileged access to game state. Our
+   agents face the same information constraints as real players. Bugs we
+   find are bugs players will find.
+
+## Engagement Tiers (Hours-Based)
+
+### Tier 1: Assessment (~1 week)
+
+**Question answered:** "Can we test this game?"
+
+| Activity | Hours |
+|----------|-------|
+| Play & study the game | 4 |
+| Set up capture pipeline, verify screenshot quality | 4 |
+| Capture 300 frames, auto-annotate, train initial YOLO | 12 |
+| Human review annotations on Roboflow | 8 |
+| Build debug loop, validate detection accuracy | 8 |
+| Write feasibility report | 4 |
+| **Total** | **40** |
+
+**Client gets:** Feasibility report, sample detection screenshots with
+bounding boxes, mAP scores per class, honest assessment of what can and
+cannot be detected, estimate for full engagement.
+
+**Go/no-go decision point.** If detection quality is insufficient (e.g.
+the game's visual style defeats YOLO at reasonable training cost), we say
+so. No point proceeding to Tier 2 with bad perception.
+
+### Tier 2: Full QA Pipeline (~3-4 weeks)
+
+**Deliverable:** Working RL agent that plays the game + QA oracle dashboard.
+
+| Activity | Hours |
+|----------|-------|
+| Tier 1 work (included) | 40 |
+| Implement game-specific Env (obs, action, reward) | 16 |
+| Configure oracles with game-specific thresholds | 8 |
+| Train RL agent (PPO, ~200k steps) | 8 |
+| Iterate reward shaping (2-3 rounds) | 16 |
+| Retrain YOLO with RL-discovered states | 8 |
+| Generate & deliver QA reports | 4 |
+| Documentation & handoff | 8 |
+| **Total** | **108** |
+
+**Client gets:** Trained RL agent, QA dashboard with bug findings, trained
+YOLO model for their game, all configs to re-run sessions independently.
+
+### Tier 3: Ongoing QA Retainer (monthly)
+
+| Activity | Hours/month |
+|----------|-------------|
+| Run nightly QA sessions (automated, review results) | 4 |
+| Review oracle findings, triage bugs | 8 |
+| Retrain YOLO/RL when game updates | 8 |
+| Monthly QA report with trends | 4 |
+| **Total** | **24/month** |
+
+## What Makes It Expensive vs. Cheap
+
+### The expensive part (human hours)
+
+- **Annotation review:** 8-12 hours per game on Roboflow (manual bounding
+  box correction). This is the single biggest cost driver.
+- **Reward function design:** Requires deeply understanding game mechanics.
+  Cannot be fully automated -- someone must decide what "good play" means.
+- **Iteration cycles:** Reward shaping and YOLO retraining are empirical.
+  Each round takes 4-8 hours.
+
+### The cheap part (automated, near-zero marginal cost)
+
+- Frame capture: fully automated random bot
+- Auto-annotation: OpenCV pipeline generates first-pass labels
+- YOLO training: ~23 min on GPU, fully scripted
+- RL training: ~2 hours for 200k steps, fully scripted
+- QA sessions: fully unattended, can run overnight/continuously
+- Report generation: fully automated HTML dashboard
+
+### How costs decrease over time
+
+| Investment | Effect |
+|------------|--------|
+| Better auto-annotation | Annotation review drops from 8-12h to 2-3h |
+| Genre templates (issue #41) | Phase 1 + 3 drop by ~50% for similar games |
+| Transfer learning | YOLO converges faster on games with similar visual style |
+| Reusable oracle configs | Less per-game threshold tuning |
+| Platform maturity | Bug fixes and edge cases already handled |
+
+**First game:** ~108 hours (Tier 2). **Second similar game:** ~60-70 hours.
+**Nth game in same genre:** ~40-50 hours.
+
+## Cost Structure for a Sustainable Business
+
+### Fixed costs (platform development & maintenance)
+
+- Platform engineering (ongoing): ~20 hours/month
+- Infrastructure (GPU compute for training): ~50-100 EUR/month
+- Roboflow subscription: ~50 EUR/month (free tier may suffice early)
+- CI/CD (GitHub Actions): free tier
+
+### Variable costs per game (one-time setup)
+
+- Tier 1 assessment: ~40 hours
+- Tier 2 full pipeline: ~68 additional hours
+- Total one-time: ~108 hours
+
+### Variable costs per game (ongoing)
+
+- Monthly retainer: ~24 hours/month
+- Compute for nightly runs: negligible (runs on existing hardware)
+
+## Competitive Landscape
+
+### What exists today
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Manual QA teams | Human intuition, flexible | Expensive, slow, doesn't scale, humans get bored |
+| Scripted test automation (Selenium, Appium) | Deterministic, repeatable | Brittle, breaks on UI changes, can't explore |
+| Game-engine-integrated testing (Unity Test Framework) | Deep access, fast | Engine-locked, requires source code, misses visual bugs |
+| AI-assisted QA (emerging) | Adaptive, can explore | Most require engine integration or API hooks |
+
+### Where RSN fits
+
+We're the **only approach that works without source code or engine
+integration**. This makes us the natural choice for:
+
+- **Publishers** testing third-party titles they didn't develop
+- **Platform holders** (Steam, console manufacturers) doing certification testing
+- **Studios** that want QA on builds before source is available to QA teams
+- **Mobile game companies** testing competitor products for market research
+- **Indie developers** who can't afford dedicated QA teams
+
+## Honest Limitations (as of session 19)
+
+- **YOLO CPU inference is ~5 FPS.** Agents play slower than humans. GPU
+  inference will solve this (>30 FPS expected).
+- **Complex UI is harder.** Nested menus, text-heavy interfaces, and
+  small UI elements are harder to detect than large game objects.
+- **No OCR yet.** We can't reliably read score, currency, or text from
+  pixels. This limits reward function design to visual object counting.
+- **First-game setup is labor-intensive.** ~108 hours is a real
+  investment. The economics improve on subsequent games.
+- **RL agents are not human-level players.** They explore differently
+  (more random, less strategic). This is actually useful for QA (they
+  find edge cases humans avoid) but means they may miss bugs that require
+  skilled play to trigger.
+
+## What We've Proven (19 Sessions)
+
+| Capability | Evidence |
+|------------|----------|
+| Pixel capture from any windowed game | PrintWindow with PW_RENDERFULLCONTENT works for GPU-composited browsers |
+| YOLO detection of game objects | mAP50=0.679 overall, ball=0.922, paddle=0.976, brick=0.995 |
+| Automated frame collection | 300 frames captured with random bot + game state detection |
+| Auto-annotation pipeline | OpenCV HSV segmentation generates first-pass YOLO labels |
+| Human-in-the-loop annotation | Roboflow integration for review and correction |
+| 12 bug-detection oracles | All implemented with on_step detection, parameterized thresholds |
+| Gymnasium RL environment | Continuous action space, modal handling, YOLO observations |
+| End-to-end pipeline validation | 4-phase debug loop: capture -> detect -> control -> gameplay |
+| 510 tests, 96% coverage | CI pipeline with ruff, pytest, Sphinx, coverage enforcement |
+
+## Next Milestones Before Going to Market
+
+1. **Complete first RL training loop** -- prove the agent learns to play
+   better than random
+2. **Generate first real QA report** from trained agent episodes
+3. **Build second game intake** to validate reusability and measure actual
+   time savings (validates the "platform" claim)
+4. **Genre templates** -- reduce per-game setup cost for common game types
+5. **GPU inference** -- achieve real-time FPS for practical training speed

--- a/documentation/business/technical_intake_workflow.md
+++ b/documentation/business/technical_intake_workflow.md
@@ -1,0 +1,170 @@
+# Technical Intake Workflow: Adding a New Game
+
+How RSN Game QA onboards a new game title. This workflow is pixel-based --
+no source code access required.
+
+## Prerequisites
+
+- RSN platform installed (conda env `yolo`, all dependencies)
+- Game runs in a window on Windows (browser, native, or emulated mobile)
+- YOLO base weights available (`yolov8n.pt`)
+- Roboflow account for annotation review
+
+## Phase 1: Game Study & Setup (8-16 hours)
+
+**Goal:** Understand the game well enough to define what to detect and how
+to control it.
+
+| Step | Task | Output |
+|------|------|--------|
+| 1.1 | Play the game manually (1-2 hours) | Notes on mechanics, UI states, win/lose conditions, input method |
+| 1.2 | Define YOLO classes | `configs/training/<game>.yaml` with class list (typically 5-15 classes) |
+| 1.3 | Create game loader config | `configs/games/<game>.yaml` (launch command, window title, resolution) |
+| 1.4 | Verify capture pipeline | Run `smoke_launch.py` -- confirm PrintWindow captures the game window correctly |
+| 1.5 | Document game mechanics | Game spec: scoring, lives/health, level progression, input method, key UI states |
+
+### Key decisions in Phase 1
+
+- **YOLO class list:** Start minimal. For Breakout 71 we use 5 classes
+  (paddle, ball, brick, powerup, wall). Resist the urge to add classes for
+  every UI element -- each class needs training data.
+- **Input method:** Determine whether the game uses mouse position
+  (continuous), keyboard (discrete), or both. This dictates action space
+  design in Phase 3.
+- **Modal/overlay detection:** Identify any DOM-based overlays (menus,
+  game-over screens, perk pickers) that block gameplay. These need
+  Selenium-based dismissal logic.
+- **Genre template:** Check if a genre template exists (see issue #41).
+  If so, inherit defaults for observation space, action space, reward
+  structure, and oracle configuration.
+
+### Lesson learned
+
+> Always study the actual game before designing. Our original Breakout 71
+> env spec was based on assumptions about how breakout games work. After
+> reading the source, we discovered scoring is coin-based (not brick-based),
+> there are no traditional lives, and mouse is the primary input. Budget
+> research time explicitly -- it prevents building the wrong thing.
+
+## Phase 2: Perception Training (16-24 hours)
+
+**Goal:** Train a YOLO model that reliably detects game objects from
+screenshots.
+
+| Step | Task | Tooling | Output |
+|------|------|---------|--------|
+| 2.1 | Capture 300-500 frames with random bot | `capture_dataset.py` | Raw frames covering gameplay, menus, transitions |
+| 2.2 | Auto-annotate with OpenCV | `auto_annotate.py` | YOLO `.txt` labels (game-specific HSV ranges needed) |
+| 2.3 | Upload to Roboflow | `upload_to_roboflow.py` | Pre-labeled dataset for human review |
+| 2.4 | Human review & correct annotations | Roboflow web UI | Corrected bounding boxes |
+| 2.5 | Prepare dataset | `prepare_dataset.py` | Train/val split in YOLO format |
+| 2.6 | Train YOLO model | `train_model.py` | `weights/<game>/best.pt` |
+| 2.7 | Validate mAP thresholds | `validate_model.py` | mAP50 >= 0.65 (first pass) |
+
+### The annotation bottleneck
+
+Human review on Roboflow (step 2.4) is the biggest time sink: 8-12 hours
+for 300 frames on the first game. This is where genre templates and
+improved auto-annotation will have the highest ROI.
+
+Current auto-annotation uses OpenCV HSV segmentation tailored to
+Breakout 71's palette. For new games, the HSV ranges and object detection
+heuristics must be adapted. Future work: train a lightweight "universal
+game object" pre-annotator that bootstraps labels across genres.
+
+### Quality thresholds
+
+| Metric | First pass (auto-annotated) | After human review |
+|--------|----------------------------|--------------------|
+| mAP@0.5 | >= 0.65 | >= 0.80 |
+| mAP@0.5:0.95 | >= 0.50 | >= 0.60 |
+
+## Phase 3: Environment & Oracles (8-16 hours)
+
+**Goal:** Build the Gymnasium environment and configure bug-detection
+oracles.
+
+| Step | Task | Output |
+|------|------|--------|
+| 3.1 | Define observation space | Mapping from YOLO detections to observation vector |
+| 3.2 | Define action space | Mouse/keyboard mapping (continuous `Box` vs `Discrete`) |
+| 3.3 | Define reward function | Based on YOLO-observable state changes only |
+| 3.4 | Implement game-specific Env | `src/env/<game>_env.py` (Gymnasium wrapper) |
+| 3.5 | Configure oracles | Select from 12 oracles, set game-specific thresholds |
+| 3.6 | Validate with debug loop | 4-phase: capture, detect, control, gameplay |
+
+### Observation space design principles
+
+- **Only use what YOLO can see.** No JS injection for game state.
+  If YOLO can't detect it, the agent can't observe it.
+- **Normalize to [0, 1].** All positions relative to game zone dimensions.
+- **Include velocity estimates.** Compute from consecutive frame
+  detections (ball_vx, ball_vy).
+- **Placeholder dimensions are OK.** Breakout 71 has `coins_norm` and
+  `score_norm` hardcoded to 0.0 because we can't yet read those from
+  pixels. SB3 learns to ignore them.
+
+### Reward function design principles
+
+- **Observable changes only.** Reward brick count decreasing (YOLO
+  detects fewer bricks), not internal score changes.
+- **Time penalty.** Small negative reward per step to encourage progress.
+- **Terminal rewards.** Large negative for game-over, large positive for
+  level-clear.
+- **Iterate empirically.** The first reward function will be wrong. Plan
+  for 2-3 rounds of adjustment after watching agent behavior.
+
+### Oracle configuration
+
+All 12 oracles are parameterized. Per-game tuning:
+
+| Oracle | What to tune |
+|--------|-------------|
+| StuckOracle | Frozen-frame threshold (depends on game speed) |
+| ScoreAnomalyOracle | Score observation index, anomaly threshold |
+| PerformanceOracle | FPS threshold (depends on YOLO speed) |
+| PhysicsViolationOracle | Object speed/acceleration limits |
+| BoundaryOracle | Game zone boundaries |
+| EpisodeLengthOracle | Expected episode duration range |
+
+## Phase 4: RL Training & QA (16-40 hours)
+
+**Goal:** Train an RL agent and generate QA reports.
+
+| Step | Task | Tooling | Output |
+|------|------|---------|--------|
+| 4.1 | Train PPO baseline (~200k steps) | `train_rl.py` | Initial policy |
+| 4.2 | Evaluate vs random baseline | `run_session.py` | Session report with oracle findings |
+| 4.3 | Iterate reward shaping (2-3 rounds) | Developer | Adjusted reward function |
+| 4.4 | Retrain YOLO with RL-collected frames | Full pipeline | Improved model for agent-discovered states |
+| 4.5 | Generate QA reports | SessionRunner | HTML dashboard with findings |
+
+### The YOLO-RL feedback loop
+
+RL training generates frames from states the random bot never reaches
+(later levels, rare game states). These frames improve YOLO training data,
+which improves observations, which improves RL performance. Plan for at
+least one full retrain cycle.
+
+## Total Time Estimate
+
+| Phase | Hours | Notes |
+|-------|-------|-------|
+| Phase 1: Game Study & Setup | 8-16 | Less if genre template exists |
+| Phase 2: Perception Training | 16-24 | Annotation review is the bottleneck |
+| Phase 3: Environment & Oracles | 8-16 | Less if genre template provides defaults |
+| Phase 4: RL Training & QA | 16-40 | Depends on game complexity and iteration |
+| **Total** | **48-96** | First game; subsequent similar games ~50-60% of this |
+
+## What's Reusable vs. Game-Specific
+
+| Reusable (platform) | Game-specific (per intake) |
+|---------------------|---------------------------|
+| WindowCapture pipeline | YOLO class list & training data |
+| YoloDetector inference | HSV ranges for auto-annotation |
+| All 12 oracles (parameterized) | Observation space mapping |
+| FrameCollector, SessionRunner | Action space & input mapping |
+| Reporting (JSON, HTML dashboard) | Reward function |
+| Training pipeline scripts | Game loader config |
+| Roboflow integration | Env wrapper |
+| Debug loop pattern | Oracle threshold tuning |


### PR DESCRIPTION
## Summary
- Add `documentation/business/technical_intake_workflow.md`: 4-phase workflow for onboarding a new game (study, perception, env, RL) with hours estimates
- Add `documentation/business/business_proposition.md`: 3-tier engagement model (Assessment/Full QA/Retainer), competitive positioning, honest limitations

Docs-only — no code changes, no Copilot review needed.