### PR TITLE
feat: alpha release prep (v0.1.0a1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, big-rock-*]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: ci
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          # Extract the section for this version from CHANGELOG.md
+          BODY=$(awk "/^## \[${TAG}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          # Write to file to preserve newlines
+          echo "$BODY" > release_body.md
+
+      - name: Determine pre-release
+        id: prerelease
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          if echo "$TAG" | grep -qE '(a|b|rc|dev)'; then
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release_body.md \
+            ${{ steps.prerelease.outputs.flag }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0a1] — 2026-02-16
+
+First alpha release. All core subsystems implemented and tested (594 tests).
+
+### Game Loader
+- YAML-driven game configuration (`configs/games/`)
+- Browser lifecycle management via Selenium (Chrome, Edge, Firefox)
+- Parcel dev server integration for browser-based games
+- Breakout 71 as first supported target
+
+### Capture & Input
+- `WindowCapture` — GDI `PrintWindow` with `PW_RENDERFULLCONTENT` for Chromium
+- `WinCamCapture` — Direct3D11 desktop duplication (<1ms async frame reads)
+- `InputController` — pydirectinput wrapper with `PAUSE=0` optimization
+
+### Perception
+- `YoloDetector` — Ultralytics YOLO wrapper with auto device detection (XPU > CUDA > CPU)
+- OpenVINO inference acceleration (~14ms/frame on Intel Arc A770 GPU)
+- OpenVINO model export script (`scripts/export_openvino.py`)
+- 5-class detection for Breakout 71: brick, paddle, ball, powerup (coin), wall
+
+### Oracles
+- 12 bug-detection oracles with `on_step` interface: Crash, Stuck, ScoreAnomaly, VisualGlitch, Performance, Physics, Boundary, StateTransition, EpisodeLength, Temporal, Reward, Soak
+
+### Gymnasium Environment
+- `Breakout71Env` — continuous `Box(-1, 1)` action space, `Box(8,)` observation
+- Selenium-based paddle control via JS `puckPosition` injection
+- Modal handling (game over, perk picker, menu) via DOM inspection
+- Headless mode support (Selenium screenshots + ActionChains)
+- Portrait (768x1024) and landscape orientation support
+
+### RL Training
+- SB3 PPO integration (`scripts/train_rl.py`)
+- `TrainingLogger` — structured JSONL events + human-readable console log
+- `FrameCollectionCallback` — capture frames during training for YOLO dataset
+- Clean shutdown via `--max-time` with SB3 callback
+- Audio mute by default, `--no-mute` flag
+
+### YOLO Training Pipeline
+- Config-driven pipeline: capture → auto-annotate → upload → train → validate
+- OpenCV auto-annotation (HSV segmentation, frame differencing)
+- Roboflow integration for annotation management
+- XPU training support with 3 ultralytics monkey patches
+- Dataset preparation script (`scripts/prepare_dataset.py`)
+
+### Orchestration
+- `FrameCollector` — periodic frame capture with auto-annotation bridge
+- `SessionRunner` — multi-episode QA evaluation sessions
+- `run_session.py` CLI for N-episode runs with JSON/HTML reporting
+
+### Reporting
+- `EpisodeReport` / `ReportGenerator` — structured JSON reports
+- `DashboardRenderer` — Jinja2 HTML dashboard
+
+### CI
+- GitHub Actions: Lint (ruff), Test (pytest), Build Check, Build Docs (Sphinx)
+- Pre-commit hook via `act` (Docker-based local CI)
+- pytest-cov with 80% minimum threshold enforced
+
+### Performance
+- 52 FPS end-to-end (wincam + OpenVINO GPU + pydirectinput)
+- ~6 FPS with Selenium modal handling every step
+- ~2.3 FPS in headless mode
+
+[0.1.0a1]: https://github.com/Roboter-Schlafen-Nicht/rsn-game-qa/releases/tag/v0.1.0a1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # rsn-game-qa
 
+[![CI](https://github.com/Roboter-Schlafen-Nicht/rsn-game-qa/actions/workflows/ci.yml/badge.svg)](https://github.com/Roboter-Schlafen-Nicht/rsn-game-qa/actions/workflows/ci.yml)
+![Version](https://img.shields.io/badge/version-0.1.0a1-blue)
+
 RL-driven autonomous game testing platform. YOLO object detection + reinforcement learning agents play games from pixels, explore bugs and balance issues, and generate human-readable test reports.
 
 **RSN** = *Roboter Schlafen Nicht* ("Robots Don't Sleep")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[project]
+name = "rsn-game-qa"
+version = "0.1.0a1"
+description = "RL-driven autonomous game testing platform"
+requires-python = ">=3.12"
+license = "LicenseRef-Proprietary"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
## Summary
- Added `[project]` section to `pyproject.toml` with `version = "0.1.0a1"`
- Created `CHANGELOG.md` summarizing all capabilities across 22 sessions
- Created `.github/workflows/release.yml` — triggered on `v*` tag push, runs CI, creates GitHub release (with `--prerelease` for alpha/beta/rc/dev tags)
- Added `workflow_call` trigger to `ci.yml` for reuse by release workflow
- Added CI and version badges to `README.md`

After merge: tag `v0.1.0a1` on main and push to trigger the release workflow.