### PR TITLE
fix: replace pydirectinput with Selenium ActionChains for all input

### DIFF
--- a/scripts/train_rl.py
+++ b/scripts/train_rl.py
@@ -187,9 +187,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help=(
             "Run browser in headless mode.  Uses Selenium screenshots "
-            "and ActionChains for capture/input instead of pydirectinput "
-            "and Win32 screen capture.  Much slower (~2-3 FPS) but does "
-            "not capture the mouse."
+            "for capture instead of Win32 screen capture.  "
+            "Much slower (~2-3 FPS) but does not capture the mouse."
         ),
     )
     parser.add_argument(

--- a/tests/test_cnn_wrapper.py
+++ b/tests/test_cnn_wrapper.py
@@ -138,7 +138,8 @@ def _make_base_env_ready(bricks_count=10):
     env._no_ball_count = 0
     env._no_bricks_count = 0
     env._last_frame = _frame()
-    env._client_origin = (100, 200)
+    env._game_canvas = mock.MagicMock()
+    env._canvas_size = (640, 480)
 
     env._capture = mock.MagicMock()
     env._capture.width = 640

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -557,11 +557,13 @@ class TestEnvBugFixes:
         env._initialized = True
         env._capture = mock.MagicMock()
         env._detector = mock.MagicMock()
-        env._client_origin = (100, 200)
+        env._game_canvas = mock.MagicMock()
+        env._canvas_size = (640, 480)
 
         env.close()
         assert env._initialized is False
-        assert env._client_origin is None
+        assert env._game_canvas is None
+        assert env._canvas_size is None
 
     def test_step_count_property(self):
         """step_count property returns _step_count."""
@@ -600,7 +602,8 @@ class TestEnvBugFixes:
 
         env = Breakout71Env(driver=mock_driver)
         env._initialized = True
-        env._client_origin = (100, 200)
+        env._game_canvas = mock.MagicMock()
+        env._canvas_size = (640, 480)
 
         mock_capture = mock.MagicMock()
         mock_detector = mock.MagicMock()


### PR DESCRIPTION
## Summary

- **Replace all OS-level mouse input (pydirectinput) with Selenium ActionChains** in both native and headless modes, fixing the pause bug where `pydirectinput.moveTo()` triggered the game's `mouseup` → `pause(true)` listener and froze the game mid-episode
- **Remove DISABLE_PAUSE_JS workaround** — the JS injection approach blocked clicks needed to start the game; Selenium ActionChains don't trigger the game's mouseup listener at all
- **Unify input codepath** — `_apply_action()` and `_click_canvas()` now use identical ActionChains logic regardless of headless mode (no more branched `_apply_action_headless` / `_click_canvas_headless`)

## Changes

### Source (`src/env/breakout71_env.py`)
- Removed `DISABLE_PAUSE_JS`, `_get_client_origin()`, `_norm_to_screen()`, `_update_client_origin()`, `_inject_disable_pause()`
- Removed `_apply_action_headless()` and `_click_canvas_headless()` — merged into unified methods
- Added `_init_canvas()` method for canvas element + size lookup via Selenium
- Replaced `_client_origin` with `_game_canvas`/`_canvas_size` (used in both modes)
- Net reduction: ~214 lines removed

### Tests
- Deleted `TestPausePrevention` class (7 tests) — no longer applicable
- Deleted `test_reset_updates_client_origin`, `test_close_clears_client_origin` (2 tests)
- Added `test_close_clears_canvas` (1 test)
- Updated all test helpers and assertions from `_client_origin` to `_game_canvas`/`_canvas_size`
- Fixed references in `test_orchestrator.py` and `test_cnn_wrapper.py`
- **640 tests pass** (was 649 — net -9 from removing obsolete tests), 96.80% coverage

### Script
- Updated `--headless` help text in `train_rl.py` to remove pydirectinput reference

## Live Validation

2-minute training session (16 episodes, 297 steps):
- **No pause bug** — game ran continuously without freezing (was 100% reproducible before)
- ~3.3 FPS (down from ~8-10 FPS with pydirectinput due to ActionChains HTTP round-trips)
- All episodes terminated naturally (game_over), zero stuck episodes
- Game-over modals detected and dismissed correctly, resets work on first attempt

## Tradeoffs

| Metric | Before (pydirectinput) | After (ActionChains) |
|---|---|---|
| FPS | ~8-10 | ~3.3 |
| Pause bug | 100% reproducible | Eliminated |
| Game-specific JS hacks | Required | None |
| Scalability to new games | Poor | Good |

The FPS drop is acceptable because the pause bug made training impossible (infinite stuck episodes), while 3.3 FPS is still usable for RL training.