### PR TITLE
docs: platform architecture spec, reward strategy spec, and roadmap update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ configs/
   games/                Game loader YAML configs (breakout-71.yaml, ...)
   training/             YOLO training configs per game (breakout-71.yaml, ...)
 scripts/                YOLO training, dataset capture, upload, smoke tests, RL training
-tests/                  pytest suite (649 unit + 24 integration tests)
+tests/                  pytest suite (640 unit + 24 integration tests)
 docs/                   Sphinx docs (Furo theme, MyST Markdown)
 documentation/
   specs/                Design specs for env, oracles, capture, reporting, game loader

--- a/documentation/specs/platform_architecture_spec.md
+++ b/documentation/specs/platform_architecture_spec.md
@@ -1,0 +1,571 @@
+# Platform Architecture: Game-Agnostic Plugin System
+
+> Authored in session 26. Defines the separation between platform
+> infrastructure and game-specific plugins, enabling the system to
+> support multiple games without per-game engineering.
+
+## Motivation
+
+The RSN Game QA platform currently works with one game (Breakout 71).
+Game-specific code is interleaved with platform infrastructure throughout
+the codebase: JS modal handling snippets, YOLO class names, observation
+vector layout, reward logic, and termination conditions are all embedded
+in `Breakout71Env`.
+
+To scale to new games, we need a clean separation:
+
+- **Platform code** handles capture, perception, RL training, oracles,
+  reporting, and session orchestration — game-agnostic infrastructure
+  that works for any game.
+- **Game plugins** provide the game-specific glue: how to detect game
+  state, how to translate actions, what constitutes "game over", and
+  optionally how to compute game-aware rewards.
+
+The goal: onboarding a new game should take **minutes** (write a config
+file and a thin plugin), not **days** (retrain YOLO, write reward logic,
+capture datasets, annotate frames).
+
+## Current State: What Is Game-Specific vs Generic
+
+Based on a full codebase analysis (session 26), the codebase is already
+~80% game-agnostic. Game-specific code is concentrated in a few files:
+
+### Fully Game-Agnostic (no changes needed)
+
+| Module | Files | Notes |
+|---|---|---|
+| Capture | `window_capture.py`, `wincam_capture.py` | Generic Windows frame capture |
+| Game Loader | `base.py`, `browser_loader.py`, `config.py`, `factory.py` | ABC + factory pattern |
+| Oracles | All 12 oracle files | Parameterised via constructor args |
+| Orchestrator | `data_collector.py` | Generic frame collector |
+| Reporting | `report.py`, `dashboard.py` | Generic JSON/HTML reporting |
+| CNN Wrapper | `cnn_wrapper.py` | Works with any env returning `info["frame"]` |
+
+### Breakout-71-Specific (must move to plugin)
+
+| File | Game-Specific Elements |
+|---|---|
+| `breakout71_env.py` | JS modal snippets, observation vector, reward function, termination logic, `#game` canvas ID, `puckPosition` injection, action mapping |
+| `breakout71_loader.py` | Parcel defaults, `.parcel-cache` cleanup |
+| `session_runner.py` | Hardcoded `Breakout71Env` import, default config/weights paths |
+| `train_rl.py` | Hardcoded env class, checkpoint names, mute JS, config paths |
+| `capture_dataset.py` | Duplicated JS modal handling, YOLO class names |
+
+### Mixed (needs refactoring)
+
+| File | Generic Part | Game-Specific Part |
+|---|---|---|
+| `yolo_detector.py` | Inference engine, device resolution | `BREAKOUT71_CLASSES` default, `detect_to_game_state()` class mapping |
+| `input_controller.py` | Key/mouse injection | `ACTION_NOOP/LEFT/RIGHT/FIRE` constants |
+| `_smoke_utils.py` | `BrowserInstance`, `Timer` | Default config `"breakout-71"` |
+
+## Target Architecture
+
+### Directory Structure
+
+```
+src/
+  platform/                     # Game-agnostic platform code
+    __init__.py
+    base_env.py                 # BaseGameEnv ABC
+    rnd_wrapper.py              # RND VecEnv wrapper (Tier 1 reward)
+    cnn_wrapper.py              # Moved from src/env/
+    game_over_detector.py       # Ensemble game-over detection
+  capture/                      # Unchanged
+    window_capture.py
+    wincam_capture.py
+    input_controller.py         # Generic input (remove Breakout constants)
+  perception/
+    yolo_detector.py            # Generic (class mapping from config)
+  oracles/                      # Unchanged (already parameterised)
+  orchestrator/
+    data_collector.py           # Unchanged
+    session_runner.py           # Accepts any BaseGameEnv (no hardcoded import)
+  reporting/                    # Unchanged
+  game_loader/                  # Unchanged (already has ABC + factory)
+
+games/                          # Game plugins (top-level, not in src/)
+  __init__.py
+  breakout71/
+    __init__.py
+    env.py                      # Breakout71Env(BaseGameEnv)
+    loader.py                   # Breakout71Loader (moved from src/game_loader/)
+    modal_handler.py            # JS snippets for Breakout 71 DOM
+    perception.py               # YOLO class names + detection mapping
+    config.yaml                 # Game config (moved from configs/games/)
+    training.yaml               # YOLO training config (moved from configs/training/)
+    reward.py                   # Optional: YOLO-based brick reward
+  # future games:
+  # tetris/
+  #   env.py
+  #   ...
+  # platformer/
+  #   ...
+
+configs/                        # Platform-level configs only
+  platform.yaml                 # Default platform settings
+
+scripts/                        # Game-agnostic CLI tools
+  train_rl.py                   # --game breakout71, loads plugin dynamically
+  run_session.py                # --game breakout71
+  capture_dataset.py            # --game breakout71
+  # game-specific scripts stay in games/<name>/scripts/ if needed
+```
+
+### The Test Horseshoe
+
+The platform wraps around the game in a horseshoe pattern:
+
+```
+                         ┌──────────────────────┐
+                         │     Game Plugin       │
+                         │                       │
+                         │  env.py (actions,      │
+                         │   obs, reward,         │
+                         │   termination,         │
+                         │   modal handling)      │
+                         │                       │
+                         │  perception.py         │
+                         │   (YOLO classes,       │
+                         │    detection mapping)  │
+                         │                       │
+                         │  config.yaml           │
+                         │   (window title,       │
+                         │    loader settings)    │
+                         └──────────┬────────────┘
+                                    │
+         ┌──────────────────────────┼──────────────────────────┐
+         │                          │                          │
+   ┌─────▼──────┐          ┌───────▼───────┐          ┌───────▼──────┐
+   │   Capture   │          │  Perception   │          │    Input     │
+   │             │          │               │          │              │
+   │ wincam /    │────────▶ │  YOLO         │────────▶ │  Selenium    │
+   │ WindowCap / │          │  (configurable│          │  ActionChains│
+   │ screenshot  │          │   classes)    │          │              │
+   └─────┬──────┘          └───────┬───────┘          └───────┬──────┘
+         │                          │                          │
+         └──────────────────────────┼──────────────────────────┘
+                                    │
+                   ┌────────────────▼────────────────────┐
+                   │         Platform Core               │
+                   │                                     │
+                   │  BaseGameEnv    (lifecycle, capture) │
+                   │  RND Wrapper    (exploration reward) │
+                   │  CNN Wrapper    (pixel observations) │
+                   │  Oracles        (passive detection)  │
+                   │  Orchestrator   (session management) │
+                   │  Reporting      (findings → reports) │
+                   │  Game Loader    (process lifecycle)  │
+                   └─────────────────────────────────────┘
+```
+
+## The Game Plugin Interface
+
+### BaseGameEnv ABC
+
+```python
+class BaseGameEnv(gymnasium.Env, ABC):
+    """Platform base class for all game environments.
+
+    Handles the common lifecycle: lazy initialisation, frame capture,
+    YOLO detection, oracle wiring, and headless/native mode branching.
+    Game plugins implement the abstract methods to provide game-specific
+    behaviour.
+    """
+
+    # ── Game plugin MUST implement these ──────────────────────────
+
+    @abstractmethod
+    def game_classes(self) -> list[str]:
+        """YOLO class names for this game.
+
+        Returns
+        -------
+        list[str]
+            e.g. ["paddle", "ball", "brick", "powerup", "wall"]
+        """
+
+    @abstractmethod
+    def build_observation(
+        self, detections: dict, reset: bool = False
+    ) -> np.ndarray:
+        """Convert raw YOLO detections to the observation vector.
+
+        Parameters
+        ----------
+        detections : dict
+            Grouped detections from YoloDetector.detect_to_game_state().
+        reset : bool
+            True on first call after reset (initialise baselines).
+        """
+
+    @abstractmethod
+    def compute_reward(
+        self, detections: dict, terminated: bool, info: dict
+    ) -> float:
+        """Compute the game-specific reward for this step.
+
+        This is the YOLO-based reward (e.g., brick counting for Breakout).
+        In survival/RND mode, the platform ignores this and uses a
+        fixed survival bonus instead.
+        """
+
+    @abstractmethod
+    def check_termination(
+        self, detections: dict
+    ) -> tuple[bool, bool, dict]:
+        """Determine if the episode has ended.
+
+        Returns
+        -------
+        tuple[bool, bool, dict]
+            (terminated, truncated, info_updates)
+        """
+
+    @abstractmethod
+    def handle_modals(self, driver, dismiss_game_over: bool = True) -> str:
+        """Detect and handle game-specific modal dialogs.
+
+        Parameters
+        ----------
+        driver : WebDriver
+            Selenium WebDriver instance.
+        dismiss_game_over : bool
+            Whether to dismiss game-over modals (True during reset,
+            False during step to preserve episode boundaries).
+
+        Returns
+        -------
+        str
+            Current game state: "gameplay", "game_over", "perk_picker",
+            "menu", or game-specific states.
+        """
+
+    @abstractmethod
+    def apply_action(
+        self, action: np.ndarray, driver, canvas, canvas_size: dict
+    ) -> None:
+        """Translate the RL action to game input.
+
+        Parameters
+        ----------
+        action : np.ndarray
+            Action from the policy (shape and semantics defined by
+            the game plugin's action_space).
+        driver : WebDriver
+            Selenium WebDriver.
+        canvas : WebElement
+            The game's canvas/container element.
+        canvas_size : dict
+            Canvas dimensions {"width": int, "height": int}.
+        """
+
+    @abstractmethod
+    def start_game(self, driver, canvas) -> None:
+        """Game-specific logic to start or restart a game.
+
+        Called during reset() after modals are handled. Typically
+        clicks the canvas, presses a key, or triggers a JS function.
+        """
+
+    @abstractmethod
+    def canvas_selector(self) -> str:
+        """CSS selector for the game's main canvas/container element.
+
+        Returns
+        -------
+        str
+            e.g. "#game", "canvas", "#game-container"
+        """
+
+    # ── Game plugin MAY override these ────────────────────────────
+
+    def on_reset_complete(self, obs: np.ndarray, info: dict) -> None:
+        """Hook called after reset() completes. Optional."""
+        pass
+
+    def on_lazy_init(self, driver) -> None:
+        """Hook called during lazy initialisation. Optional.
+
+        Use for one-time setup like muting audio, injecting CSS, etc.
+        """
+        pass
+
+    # ── Platform provides these (not overridden) ──────────────────
+
+    def reset(self, seed=None, options=None):
+        """Standard lifecycle."""
+        # 1. super().reset(seed=seed)
+        # 2. _lazy_init() if needed
+        # 3. handle_modals(dismiss_game_over=True)
+        # 4. start_game()
+        # 5. _capture_frame()
+        # 6. _detect_objects()
+        # 7. build_observation(reset=True)
+        # 8. on_reset_complete()
+        # 9. oracle.on_reset()
+        ...
+
+    def step(self, action):
+        """Standard lifecycle."""
+        # 1. apply_action()
+        # 2. handle_modals(dismiss_game_over=False) [throttled]
+        # 3. _capture_frame()
+        # 4. _detect_objects()
+        # 5. build_observation()
+        # 6. check_termination()
+        # 7. compute_reward() or survival_reward() [based on mode]
+        # 8. oracle.on_step()
+        ...
+```
+
+### Game Plugin Registration
+
+Games are discovered via a registry pattern, similar to the existing
+`GameLoader` factory:
+
+```python
+# games/breakout71/__init__.py
+from src.platform.base_env import register_game
+
+@register_game("breakout71")
+class Breakout71Plugin:
+    env_class = Breakout71Env
+    loader_class = Breakout71Loader
+    config_path = "games/breakout71/config.yaml"
+```
+
+Scripts load games by name:
+
+```bash
+# Train RL on Breakout 71
+python scripts/train_rl.py --game breakout71 --reward-mode rnd --policy cnn
+
+# Train RL on a future game
+python scripts/train_rl.py --game tetris --reward-mode rnd --policy cnn
+```
+
+### Game Plugin Minimal Example
+
+To onboard a new game with **zero YOLO training**, using only CNN
+observations and survival + RND reward:
+
+```python
+# games/simple_platformer/env.py
+
+class SimplePlatformerEnv(BaseGameEnv):
+    observation_space = spaces.Box(0, 255, (84, 84, 1), dtype=np.uint8)
+    action_space = spaces.Box(-1, 1, (2,), dtype=np.float32)  # x, y movement
+
+    def game_classes(self) -> list[str]:
+        return []  # No YOLO — CNN only
+
+    def build_observation(self, detections, reset=False):
+        return np.zeros(0)  # Not used in CNN mode
+
+    def compute_reward(self, detections, terminated, info):
+        return 0.0  # Not used in RND mode — survival reward from platform
+
+    def check_termination(self, detections):
+        # Use the platform's ensemble game-over detector
+        game_over = self._game_over_detector.is_game_over(self._last_frame)
+        return game_over, self._step_count >= self.max_steps, {}
+
+    def handle_modals(self, driver, dismiss_game_over=True):
+        return "gameplay"  # Simple game, no modals
+
+    def apply_action(self, action, driver, canvas, canvas_size):
+        # Map 2D action to mouse position
+        x = int((action[0] + 1) / 2 * canvas_size["width"])
+        y = int((action[1] + 1) / 2 * canvas_size["height"])
+        ActionChains(driver).move_to_element_with_offset(
+            canvas, x - canvas_size["width"] // 2,
+            y - canvas_size["height"] // 2
+        ).perform()
+
+    def start_game(self, driver, canvas):
+        ActionChains(driver).click(canvas).perform()
+
+    def canvas_selector(self):
+        return "canvas"
+```
+
+This plugin is ~40 lines. No YOLO model, no training data, no
+annotation pipeline. The platform handles everything else.
+
+## Observation Modes
+
+### CNN (Default — Game-Agnostic)
+
+```
+Raw frame → CnnObservationWrapper → 84x84 grayscale → VecFrameStack(4) → Policy
+```
+
+- No YOLO required
+- Works for any game immediately
+- The CNN policy learns visual features from reward signal (+ RND)
+- Slower to train but universally applicable
+
+### MLP (Optional — Requires Game-Specific YOLO)
+
+```
+Raw frame → YoloDetector → game_classes() mapping → build_observation() → Policy
+```
+
+- Requires a trained YOLO model with game-specific classes
+- Plugin must implement `build_observation()` with meaningful features
+- Faster training (pre-extracted features) but high onboarding cost
+- Available as `--policy mlp` when the game plugin provides YOLO support
+
+### Decision
+
+CNN is the **default** observation mode. It requires zero game-specific
+setup and aligns with the platform's game-agnostic mission. MLP is an
+**optional enhancement** for games where a YOLO model is available
+(e.g., Breakout 71).
+
+## YOLO in the Platform
+
+`YoloDetector` remains a platform-level service. Game plugins configure
+it rather than owning it:
+
+```python
+# Platform: YoloDetector
+class YoloDetector:
+    def __init__(self, weights_path, classes=None, device="auto"):
+        self._classes = classes  # From game plugin, or inferred from model
+
+    def detect_to_game_state(self, frame, class_mapping=None):
+        """Group detections by class.
+
+        Parameters
+        ----------
+        class_mapping : dict[int, str] | None
+            Override class name mapping. If None, use model's own names.
+        """
+        ...
+```
+
+The game plugin provides class names via `game_classes()`. If the plugin
+returns an empty list (no YOLO), the detector is not initialised and
+CNN mode is used exclusively.
+
+## Reward Mode: Platform-Level Override
+
+The reward mode is a **platform decision**, not a game plugin decision.
+The `--reward-mode` CLI flag applies to any game:
+
+| Mode | Source | Game Plugin Involvement |
+|---|---|---|
+| `yolo` | `plugin.compute_reward()` | Plugin computes reward from YOLO detections |
+| `survival` | Platform fixed formula | Plugin not consulted; +0.01 survival, -5.0 game over |
+| `rnd` | Platform survival + RND wrapper | Plugin not consulted; exploration bonus from wrapper |
+
+The platform's `step()` method selects the reward source:
+
+```python
+# In BaseGameEnv.step()
+if self._reward_mode == "yolo":
+    reward = self.compute_reward(detections, terminated, info)
+elif self._reward_mode in ("survival", "rnd"):
+    reward = 0.01  # survival bonus
+    if terminated and not level_cleared:
+        reward = -5.0  # game-over penalty
+# RND bonus is added externally by the VecEnv wrapper, not here
+```
+
+## Migration Plan
+
+The refactoring is a **behaviour-preserving** change. The goal is to
+move code, not change logic. All 640+ existing tests must continue to
+pass after refactoring.
+
+### Phase 1: Extract BaseGameEnv
+
+1. Create `src/platform/base_env.py` with the ABC
+2. Make `Breakout71Env` inherit from `BaseGameEnv`
+3. Move generic lifecycle code to `BaseGameEnv`
+4. Move Breakout-specific code to the abstract method implementations
+5. All tests pass unchanged
+
+### Phase 2: Create games/ directory
+
+1. Create `games/breakout71/` with plugin files
+2. Move `breakout71_loader.py` → `games/breakout71/loader.py`
+3. Move JS modal snippets → `games/breakout71/modal_handler.py`
+4. Move YOLO class constants → `games/breakout71/perception.py`
+5. Move config YAML → `games/breakout71/config.yaml`
+6. Update imports throughout
+
+### Phase 3: Refactor scripts
+
+1. `train_rl.py` — accept `--game` flag, load plugin dynamically
+2. `run_session.py` — same
+3. `session_runner.py` — accept any `BaseGameEnv` subclass
+4. `capture_dataset.py` — parameterise by game
+
+### Phase 4: Move CnnObservationWrapper
+
+1. Move `src/env/cnn_wrapper.py` → `src/platform/cnn_wrapper.py`
+2. Update imports
+
+### Validation
+
+After each phase, run the full test suite to verify no regressions:
+
+```bash
+conda run -n yolo pytest tests/ -x -q
+```
+
+## What This Enables
+
+Once the plugin architecture is in place:
+
+1. **New game in minutes:** Write a ~40-line plugin, point at the game's
+   URL, run `python scripts/train_rl.py --game my_game --reward-mode rnd`
+2. **A/B reward strategies:** Compare RND vs YOLO-based reward on the
+   same game without code changes (`--reward-mode rnd` vs `--reward-mode yolo`)
+3. **Shared improvements:** Better RND, better oracles, better capture —
+   all games benefit automatically
+4. **Community contributions:** Game plugins are self-contained; third
+   parties can contribute new game support without touching platform code
+5. **Testing isolation:** Platform tests are game-agnostic; game plugin
+   tests are isolated to `games/<name>/tests/`
+
+## Architectural Decisions Record
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Plugin location | `games/` (top-level) | Games are not part of the platform package |
+| Default observation | CNN (84x84 grayscale) | Game-agnostic, no YOLO required |
+| MLP observation | Optional plugin feature | Requires game-specific YOLO model |
+| YOLO ownership | Platform with configurable classes | Avoids duplicating inference infrastructure |
+| Reward mode | Platform-level override | `--reward-mode` works for any game |
+| Implementation order | Architecture first, then RND | Clean foundation before adding features |
+| Migration strategy | Behaviour-preserving refactor | All existing tests must pass |
+
+## Source Files (After Implementation)
+
+### Platform (new)
+- `src/platform/__init__.py`
+- `src/platform/base_env.py` — BaseGameEnv ABC
+- `src/platform/rnd_wrapper.py` — RND VecEnv wrapper
+- `src/platform/cnn_wrapper.py` — moved from `src/env/`
+- `src/platform/game_over_detector.py` — ensemble detector
+
+### Game Plugin (Breakout 71)
+- `games/__init__.py`
+- `games/breakout71/__init__.py` — plugin registration
+- `games/breakout71/env.py` — Breakout71Env(BaseGameEnv)
+- `games/breakout71/loader.py` — moved from `src/game_loader/`
+- `games/breakout71/modal_handler.py` — JS snippets
+- `games/breakout71/perception.py` — YOLO classes + mapping
+- `games/breakout71/reward.py` — YOLO brick-counting reward
+- `games/breakout71/config.yaml` — game config
+- `games/breakout71/training.yaml` — YOLO training config
+
+### Refactored (existing files, updated)
+- `src/perception/yolo_detector.py` — remove `BREAKOUT71_CLASSES` default
+- `src/orchestrator/session_runner.py` — accept any `BaseGameEnv`
+- `scripts/train_rl.py` — `--game` flag, dynamic plugin loading
+- `scripts/run_session.py` — `--game` flag

--- a/documentation/specs/reward_strategy_spec.md
+++ b/documentation/specs/reward_strategy_spec.md
@@ -1,0 +1,361 @@
+# Reward Strategy: Exploration-Driven QA
+
+> Authored in session 26. Defines the three-tier reward architecture for
+> game-agnostic QA exploration. This spec replaces the v2 reward roadmap
+> in `breakout71_env_spec.md`.
+
+## Why QA Testers Are Not Game Players
+
+A game player maximises score. A QA tester maximises **coverage** of game
+states. These are fundamentally different objectives, and the reward
+function must reflect this.
+
+A score-maximising RL agent will:
+
+- Learn one dominant strategy and repeat it every episode
+- Avoid risky or unusual actions (they lower expected reward)
+- Never pick "bad" perks (even though those code paths need testing)
+- Never explore game states that don't lead to high scores
+- Be a poor QA tester
+
+An exploration-maximising RL agent will:
+
+- Visit many different game states across episodes
+- Try different perk combinations, even suboptimal ones
+- Play in unexpected ways — exactly how real users find bugs
+- Sometimes die quickly, sometimes survive a long time
+- Exercise edge cases that a score-optimal policy would never reach
+
+The platform's 12 oracles are passive observers. They can only detect bugs
+in states the agent actually visits. An agent that always plays the same
+optimal strategy will never trigger the oracles on the vast majority of
+game states where bugs are most likely to hide.
+
+**The agent's job is to generate rich, diverse play traces.
+The oracles' job is to inspect those traces for anomalies.**
+
+## Game-Agnostic Reward Requirements
+
+As a QA platform, we must support new games without rewriting reward
+functions. The current YOLO-based brick-counting reward requires:
+
+1. A trained YOLO model for the specific game
+2. Game-specific detection-to-reward mapping logic
+3. Knowledge of what constitutes "progress" in that game
+
+This does not scale. For a new game, the onboarding cost is prohibitive:
+capture frames, annotate objects, train YOLO, write reward logic, tune
+hyperparameters — all before the agent takes its first step.
+
+The reward function must work with **minimal game-specific knowledge**.
+The only truly universal signal across all games is:
+
+- **The game is still running** (survival)
+- **The current state is different from previously seen states** (novelty)
+- **The game ended** (game-over detection)
+
+Everything else — score, lives, level progression, power-ups — is
+game-specific and should be treated as optional enrichment, not a
+requirement.
+
+## Three-Tier Reward Architecture
+
+### Tier 1: Survival + Novelty (RND) — Current Priority
+
+**Reward formula:**
+
+```
+reward = survival_bonus + intrinsic_novelty_bonus
+       = 0.01 + normalized_rnd_prediction_error
+```
+
+**Game knowledge required:** Game-over detection only.
+
+**How RND (Random Network Distillation) works:**
+
+RND (Burda et al., 2018) provides an intrinsic motivation signal without
+any game-specific knowledge:
+
+1. A **target network** is randomly initialised and **never trained**.
+   It maps observations to a 512-dimensional embedding.
+2. A **predictor network** (same architecture + deeper head) is trained
+   to match the target network's output via MSE loss.
+3. For frequently-visited states, the predictor learns to match the
+   target accurately — low prediction error, low novelty bonus.
+4. For rarely-visited states, the predictor has high error — high
+   novelty bonus, encouraging the agent to revisit.
+
+The novelty bonus decays naturally as the agent explores: states that
+were once novel become familiar, pushing the agent toward unexplored
+regions of the state space.
+
+#### RND Network Architecture
+
+**Target network** (fixed, randomly initialised):
+
+| Layer | Type | Details |
+|---|---|---|
+| Conv1 | Conv2d | 32 filters, 8x8, stride 4, LeakyReLU |
+| Conv2 | Conv2d | 64 filters, 4x4, stride 2, LeakyReLU |
+| Conv3 | Conv2d | 64 filters, 3x3, stride 1, LeakyReLU |
+| Flatten | — | — |
+| FC | Linear | → 512 output |
+
+**Predictor network** (trainable):
+
+Same convolutional backbone as target, plus:
+
+| Layer | Type | Details |
+|---|---|---|
+| FC1 | Linear | 512 → 512, ReLU |
+| FC2 | Linear | 512 → 512, ReLU |
+| FC3 | Linear | 512 → 512 output |
+
+The deeper head gives the predictor more capacity, but it still cannot
+perfectly match the target on novel states because the target's random
+weights create an unpredictable mapping.
+
+**Input:** Single frame (not stacked), normalised by running mean/std,
+clipped to [-5, 5]. RND operates on individual observations, not
+temporal sequences — the frame stack is only for the policy network.
+
+#### Intrinsic Reward Computation
+
+```python
+# Computed per step
+target_embedding = stop_gradient(target_network(normalize(obs)))
+predicted_embedding = predictor_network(normalize(obs))
+intrinsic_reward = mse_loss(predicted_embedding, target_embedding)
+```
+
+#### Intrinsic Reward Normalisation (Critical)
+
+Raw intrinsic rewards can be orders of magnitude larger than extrinsic
+rewards. Without normalisation, intrinsic rewards dominate and training
+becomes unstable.
+
+1. Apply a **reward forward filter** (discounted running sum with gamma)
+   to the stream of intrinsic rewards
+2. Divide by `sqrt(running_variance)` — **no mean subtraction**, only
+   standard deviation scaling
+3. The result is a normalised bonus with roughly unit variance
+
+**Important:** Intrinsic rewards are **non-episodic**. Do not zero them
+out on episode boundaries. The agent should remain curious about novel
+states regardless of episode structure.
+
+#### SB3 Integration: VecEnv Wrapper
+
+The simplest integration with Stable Baselines 3:
+
+```python
+class RNDRewardWrapper(VecEnvWrapper):
+    """Add RND intrinsic reward bonus to environment rewards."""
+
+    def __init__(self, venv, int_coeff=1.0, ext_coeff=2.0, ...):
+        self.target_network = RNDTargetNetwork(obs_shape)  # fixed
+        self.predictor_network = RNDPredictorNetwork(obs_shape)  # trainable
+        self.reward_normalizer = RunningMeanStd()
+        self.obs_normalizer = RunningMeanStd()
+
+    def step_wait(self):
+        obs, reward, done, info = self.venv.step_wait()
+        intrinsic = self._compute_intrinsic_reward(obs)
+        normalized_intrinsic = self._normalize_reward(intrinsic)
+        combined = self.ext_coeff * reward + self.int_coeff * normalized_intrinsic
+        self._update_predictor(obs)  # train predictor on this batch
+        return obs, combined, done, info
+```
+
+This approach uses SB3's single value head with combined rewards. A
+faithful RND implementation would use dual value heads (separate
+extrinsic and intrinsic advantage estimates), but the single-head
+wrapper is sufficient for initial validation. Upgrade to dual heads
+only if training shows instability.
+
+#### Hyperparameters
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `int_coeff` | 1.0 | Intrinsic reward weight |
+| `ext_coeff` | 2.0 | Extrinsic reward weight |
+| `gamma_int` | 0.99 | Intrinsic discount factor (non-episodic) |
+| `gamma_ext` | 0.999 | Extrinsic discount factor |
+| `predictor_lr` | 1e-3 | Predictor network learning rate |
+| `embedding_dim` | 512 | RND embedding dimension |
+| `update_proportion` | 0.25 | Fraction of experience for predictor updates |
+
+#### CNN vs MLP Considerations
+
+- **CNN (84x84 grayscale, 4-frame stack):** RND is most valuable here.
+  Pixel observations have rich visual structure — different brick layouts,
+  ball positions, perk effects, modal states all produce distinct
+  embeddings. RND naturally rewards visiting visually distinct states.
+- **MLP (8-dim YOLO vector):** RND offers limited benefit. The state
+  space is compact (8 floats) and PPO can explore it adequately without
+  intrinsic motivation. The 8-dim space may not have enough structure
+  for RND prediction errors to be meaningful.
+
+**Decision:** CNN is the default observation mode for game-agnostic
+operation. MLP is an optional enhancement when a game-specific YOLO
+model is available (see `platform_architecture_spec.md`).
+
+#### What Changes in the Env
+
+- `_compute_reward()` gains a `survival` mode: only returns the small
+  survival bonus (+0.01) and terminal penalty (-5.0 on game over).
+  No brick counting, no YOLO dependency for reward.
+- The RND bonus is added **externally** by the VecEnv wrapper, not
+  inside the env. This keeps the env clean and the RND logic reusable.
+- CLI flag `--reward-mode yolo|survival|rnd` selects the mode:
+  - `yolo`: current brick-counting reward (requires YOLO, game-specific)
+  - `survival`: survival bonus + terminal penalty only (game-agnostic)
+  - `rnd`: survival reward + RND wrapper (game-agnostic, exploration)
+
+#### What Stays Unchanged
+
+- Observation spaces (CNN 84x84, MLP 8-dim)
+- Action space (Box(-1, 1))
+- Episode lifecycle (reset, step, close)
+- Oracle system (passive, decoupled from reward)
+- Capture pipeline (wincam, WindowCapture, headless)
+- Modal handling (game-specific, in game plugin — see architecture spec)
+
+### Tier 2: Score-Aware Exploration (OCR)
+
+**Reward formula:**
+
+```
+reward = survival_bonus + novelty_bonus + score_delta_bonus
+```
+
+**Game knowledge required:** A visible score on screen (most games).
+
+**Implementation:**
+
+1. Define a score region in the game frame (configurable per game, or
+   auto-detected via OCR scanning)
+2. Run OCR (Tesseract or EasyOCR) on the score region each frame
+3. Compute `score_delta = current_score - previous_score`
+4. Add `score_delta * scale_factor` to the reward
+
+**Why this helps:** Pure survival + novelty can lead to aimless
+wandering. The score signal provides a gentle nudge toward "making
+progress" — which helps the agent reach later game states (level 2,
+level 3) where different bugs may hide. But it's secondary to
+exploration: the agent should not sacrifice novelty for score.
+
+**Game-agnostic properties:** Most games display a visible score.
+OCR is a universal technique. The only game-specific element is the
+score region location, which can be provided via game config or
+auto-detected.
+
+**Timing:** Implement after Tier 1 is validated. Score OCR adds
+latency (~50-100ms per frame with Tesseract) and complexity.
+
+### Tier 3: Oracle-Guided Exploration (Future Research)
+
+**Reward formula:**
+
+```
+reward = survival_bonus + novelty_bonus + oracle_proximity_bonus
+```
+
+**Game knowledge required:** None beyond Tier 1.
+
+**Concept:** When an oracle detects an anomaly (visual glitch, physics
+violation, stuck state), boost the exploration reward for states
+*near* that anomaly. The agent learns to revisit suspicious areas,
+essentially performing **directed fuzzing**.
+
+**Implementation sketch:**
+
+1. Oracle findings include a state fingerprint (frame hash or
+   observation vector at the time of detection)
+2. Maintain a buffer of recent findings with their state fingerprints
+3. For each new observation, compute distance to the nearest finding
+4. If close to a known anomaly, add a proximity bonus to the reward
+5. The agent is drawn back to anomalous regions, increasing the
+   chance of reproducing bugs
+
+**Open questions:**
+
+- How to define "proximity" in observation space (pixel space? latent
+  space? RND embedding space?)
+- How to decay the proximity bonus (avoid the agent getting stuck in
+  a loop around one anomaly)
+- How to balance directed exploration with undirected novelty-seeking
+
+**Timing:** Research phase. Implement after Tiers 1 and 2 are proven.
+
+## Game-Over Detection Generalisation
+
+Game-over detection is the **only** game-specific knowledge required
+for Tier 1. Currently, Breakout 71 uses DOM modal inspection
+(`document.body.classList.contains('has-alert-open')`). For unknown
+games, we need generic detection strategies.
+
+### Detection Strategies
+
+| Strategy | How It Works | Strengths | Weaknesses |
+|---|---|---|---|
+| **Screen freeze** | Pixel diff < threshold for N frames | Works for any game | False positive on pause menus, cutscenes |
+| **OCR text matching** | Scan for "Game Over", "You Died", "Continue?" | High confidence when matched | Language-dependent, font-dependent |
+| **Entropy collapse** | Frame entropy drops below threshold (static screen) | Detects modal overlays | False positive on loading screens |
+| **Input responsiveness** | Send actions, check if state changes | Detects stuck/frozen states | Slow (requires multiple frames) |
+| **Audio silence** | Game audio stops (if available) | Independent of visual state | Not all games have audio cues |
+| **Frame classification** | Train a small CNN to classify "playing" vs "not playing" | Accurate once trained | Requires labelled data per game |
+
+### Recommended Approach: Ensemble Detector
+
+No single strategy is reliable enough alone. An ensemble detector
+combines multiple signals with configurable weights:
+
+```python
+class GameOverDetector:
+    """Ensemble game-over detector with configurable strategies."""
+
+    def __init__(self, strategies: list[GameOverStrategy], threshold: float = 0.6):
+        self.strategies = strategies
+        self.threshold = threshold
+
+    def is_game_over(self, frame, prev_frame, ...) -> tuple[bool, float]:
+        """Return (is_game_over, confidence) based on weighted vote."""
+        ...
+```
+
+Each game config can specify which strategies to use and their weights.
+For Breakout 71, the DOM modal check provides a high-confidence signal
+and can be the sole strategy. For unknown games, the ensemble provides
+robustness.
+
+**Timing:** Implement incrementally. Start with screen freeze + OCR
+text matching as the first generic strategies. Add others as needed
+when onboarding new games.
+
+## Comparison: Current vs Tier 1
+
+| Aspect | Current (YOLO + brick reward) | Tier 1 (survival + RND) |
+|---|---|---|
+| Game knowledge | YOLO model + brick counting | Game-over detection only |
+| Scales to new games | No (retrain YOLO, rewrite reward) | Yes (only need game-over signal) |
+| Agent behaviour | Score-maximising (repetitive) | Exploration-maximising (diverse) |
+| Training speed | Faster (dense reward signal) | Slower (sparse extrinsic + intrinsic) |
+| QA value | Low (one strategy, misses edge cases) | High (diverse states, exercises perks) |
+| Observation mode | MLP (requires YOLO) or CNN | CNN (game-agnostic, no YOLO needed) |
+| Onboarding a new game | Days (data collection, annotation, training) | Minutes (config + game-over detector) |
+
+## References
+
+- Burda et al., "Exploration by Random Network Distillation", ICLR 2019
+- Laskin et al., "CURL: Contrastive Unsupervised Representations for RL", ICML 2020
+- Laskin et al., "Reinforcement Learning with Augmented Data (RAD)", NeurIPS 2020
+- Yarats et al., "Mastering Visual Continuous Control (DrQ-v2)", 2021
+- Schwarzer et al., "Self-Predictive Representations (SPR)", ICLR 2021
+
+## Source Files (After Implementation)
+
+- `src/platform/rnd_wrapper.py` — RND VecEnv wrapper
+- `src/platform/base_env.py` — BaseGameEnv with survival reward mode
+- `games/breakout71/reward.py` — Breakout-specific YOLO reward (optional)
+- `scripts/train_rl.py` — `--reward-mode` CLI flag


### PR DESCRIPTION
## Summary

- Add platform architecture spec (`documentation/specs/platform_architecture_spec.md`): BaseGameEnv ABC, game plugin system, observation modes, YOLO as configurable platform service, 4-phase migration plan
- Add reward strategy spec (`documentation/specs/reward_strategy_spec.md`): three-tier reward architecture (survival+RND, OCR score delta, oracle-guided), full RND implementation details, game-over generalization strategies
- Update checklist (`documentation/BigRocks/checklist.md`): new section 4 with ~30 subtasks for platform architecture and exploration-driven reward
- Update AGENTS.md: session 26 entry, discoveries section, test counts (664 total), What's Next updated
- Update README.md: test count (640 unit + 24 integration)

Docs-only PR — no code changes.