### PR TITLE
docs: post-merge admin for PRs #65, #67, and Copilot ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,27 @@ The system uses a two-layer design:
 
 ```
 src/
+  platform/             BaseGameEnv ABC, CnnObservationWrapper (game-agnostic)
   capture/              Window capture (GDI) + input controller (pydirectinput)
-  env/                  Gymnasium environments (Breakout71Env)
+  env/                  Backward-compat re-exports for game environments
   game_loader/          Configurable game loading (browser dev server lifecycle)
   oracles/              Bug-detection oracles (crash, stuck, score, visual, perf, physics, boundary, state, episode_length, temporal, reward, soak)
   orchestrator/         Session orchestration (FrameCollector, SessionRunner)
   perception/           YOLO detector wrapper + Breakout 71 capture helpers
   reporting/            Episode/session reports + Jinja2 HTML dashboard
+games/
+  breakout71/           Breakout 71 game plugin (env, loader, modal handler, perception)
 configs/
   games/                Game loader YAML configs (breakout-71.yaml, ...)
   training/             YOLO training configs per game (breakout-71.yaml, ...)
 scripts/                YOLO training, dataset capture, upload, smoke tests, RL training
-tests/                  pytest suite (680 unit + 24 integration tests)
+tests/                  pytest suite (669 unit + 24 integration tests)
 docs/                   Sphinx docs (Furo theme, MyST Markdown)
 documentation/
   specs/                Design specs for env, oracles, capture, reporting, game loader
-  sessions/             Development session notes
-  business/             2026 plan
+  BigRocks/             Master checklist and task tracking
+  reference/            Agent knowledge base (technical discoveries)
+  ROADMAP.md            5-phase development plan
 ```
 
 ## Hardware
@@ -115,7 +119,7 @@ GitHub Actions runs on every push to `main` or `big-rock-*` branches and on PRs 
 | Job | What it does |
 |-----|-------------|
 | **Lint** | `ruff check` + `ruff format --check` |
-| **Test** | `pytest -m "not integration"` (680 passed) |
+| **Test** | `pytest -m "not integration"` (669 passed) |
 | **Build Check** | Verifies all module imports succeed |
 | **Build Docs** | Sphinx HTML build with `-W` (warnings as errors) |
 

--- a/documentation/BigRocks/checklist.md
+++ b/documentation/BigRocks/checklist.md
@@ -234,7 +234,7 @@
 
 > See `documentation/ROADMAP.md` for the full 5-phase plan.
 
-- [ ] Merge PR #65 (`--game` flag and dynamic plugin loading)
+- [x] Merge PR #65 (`--game` flag and dynamic plugin loading) — session 30
 - [ ] Run 200K-step PPO training (CNN policy, portrait, `--max-time 7200`)
 - [ ] Evaluate trained model: 10-episode eval with `run_session.py`
 - [ ] Generate QA report with oracle findings and HTML dashboard
@@ -248,6 +248,24 @@
 - [x] Create `documentation/ROADMAP.md` — 5-phase plan
 - [x] Rewrite `AGENTS.md` — lean ~120-line operational guide (was 449 lines)
 - [x] Update `documentation/BigRocks/checklist.md` — mark done items, add Phase 1 tasks
+
+### 7. Public repo hardening & CI automation (session 31)
+
+- [x] **PR #67: Public repo hardening**
+  - [x] Security audit (135 commits) — no secrets in git history
+  - [x] Removed hardcoded local paths (8 files, ~14 locations)
+  - [x] Deleted dead `scripts/train.py` (referenced wrong project)
+  - [x] Added MIT License
+  - [x] Created `.github/copilot-instructions.md` (review guidelines)
+  - [x] Hardened `.gitignore` (certs, credentials, databases)
+  - [x] Hardened `ci.yml` (`permissions: contents: read`)
+  - [x] Session logs moved to `private/` (gitignored)
+  - [x] Repo made public
+- [x] **Copilot review ruleset** (`copilot-review-for-main`, ID 12909207)
+  - [x] Target: default branch (`main`)
+  - [x] Copilot auto-reviews PRs on creation and on push
+  - [x] Draft PRs excluded from auto-review
+  - [x] 0 required approvals (Copilot reviews but doesn't block)
 
 #### Deferred
 - [ ] Retrain YOLO with human-reviewed Roboflow annotations

--- a/documentation/ROADMAP.md
+++ b/documentation/ROADMAP.md
@@ -17,7 +17,7 @@ evaluating it, and generating a QA report with real oracle findings.
 
 | Task | Details |
 |---|---|
-| Merge PR #65 | `--game` flag and dynamic plugin loading |
+| Merge PR #65 | `--game` flag and dynamic plugin loading — **DONE** |
 | Run 200K-step PPO training | CNN policy, portrait mode, `--max-time 7200` |
 | Run 10-episode evaluation | `run_session.py --game breakout71 --episodes 10` |
 | Generate QA report | Oracle findings, episode metrics, HTML dashboard |


### PR DESCRIPTION
## Summary

- Updated checklist: marked PR #65 merge complete in Phase 1, added PR #67 and Copilot ruleset entries
- Updated ROADMAP: marked PR #65 task as done
- Updated README: added `platform/` and `games/` to project structure, fixed test count (669 unit + 24 integration), replaced stale `sessions/` and `business/` references with current documentation structure
- Updated repo description on GitHub

This PR also serves as an end-to-end test of the new Copilot review ruleset (ID 12909207).