### PR TITLE
fix: resolve three bugs blocking headless game start in training

### DIFF
--- a/games/breakout71/__init__.py
+++ b/games/breakout71/__init__.py
@@ -36,3 +36,14 @@ default_weights = "weights/breakout71/best.pt"
 # JS snippet to mute game audio (executed once before training starts).
 # If not present, no mute action is taken.
 mute_js = 'localStorage.setItem("breakout-settings-enable-sound", "false")'
+
+# JS snippet to configure game settings for RL training.
+# Disables mobile-mode (touch-hold UI) and delayed start (3-second countdown)
+# so that a single mouseup event starts the game immediately.
+# Executed once before training starts; requires a page refresh to take effect.
+setup_js = "\n".join(
+    [
+        'localStorage.setItem("breakout-settings-enable-mobile-mode", "false");',
+        'localStorage.setItem("breakout-settings-enable-touch_delayed_start", "false");',
+    ]
+)

--- a/scripts/train_rl.py
+++ b/scripts/train_rl.py
@@ -785,14 +785,25 @@ def main(argv: list[str] | None = None) -> int:
 
     # -- Mute game audio ---------------------------------------------------
     mute_js = getattr(plugin, "mute_js", None)
+    setup_js = getattr(plugin, "setup_js", None)
+    needs_refresh = False
     if args.mute and mute_js and browser_instance.driver is not None:
         try:
             browser_instance.driver.execute_script(mute_js)
-            browser_instance.driver.refresh()
+            needs_refresh = True
             logger.info("Game audio muted via plugin mute_js")
-            time.sleep(3)  # let page reload with muted audio
         except Exception as exc:
             logger.warning("Failed to mute game audio: %s", exc)
+    if setup_js and browser_instance.driver is not None:
+        try:
+            browser_instance.driver.execute_script(setup_js)
+            needs_refresh = True
+            logger.info("Game settings configured via plugin setup_js")
+        except Exception as exc:
+            logger.warning("Failed to apply game setup_js: %s", exc)
+    if needs_refresh:
+        browser_instance.driver.refresh()
+        time.sleep(3)  # let page reload with new settings
 
     # -- Log config event --------------------------------------------------
     tlog.log(

--- a/tests/test_game_plugins.py
+++ b/tests/test_game_plugins.py
@@ -94,6 +94,15 @@ class TestLoadGamePlugin:
         # mute_js is optional — its presence shouldn't matter for loading
         assert hasattr(plugin, "mute_js")
 
+    def test_breakout71_has_setup_js(self):
+        """Breakout71 plugin should define setup_js for RL training settings."""
+        plugin = load_game_plugin("breakout71")
+
+        assert hasattr(plugin, "setup_js")
+        setup_js = plugin.setup_js
+        assert "mobile-mode" in setup_js
+        assert "touch_delayed_start" in setup_js
+
 
 class TestGetEnvClass:
     """Tests for get_env_class()."""


### PR DESCRIPTION
## Summary

Fixes three bugs that caused the first 200K training run to produce zero learning (bricks=1, reward=-0.010, paddle_x=0.498 never changing for 33K+ steps).

- **Bug 1 (game never started):** `start_game()` now sets `gameState.running = true` and `gameState.ballStickToPuck = false` directly via JS instead of ActionChains click, bypassing the async `applyFullScreenChoice()` guard that silently blocks `play()` in headless Chrome
- **Bug 2 (mobile-mode blocking):** Added `setup_js` plugin attribute that disables `mobile-mode` and `touch_delayed_start` localStorage settings (press-and-hold countdown UI)
- **Bug 3 (YOLO 1-brick):** Consequence of Bug 1 — with game not started, no bricks rendered. Should resolve once game actually starts

## Changes

| File | Change |
|---|---|
| `games/breakout71/__init__.py` | Added `setup_js` attribute to disable mobile-mode and delayed start |
| `games/breakout71/env.py` | Rewrote `start_game()` to use JS gameState mutation with ActionChains fallback |
| `scripts/train_rl.py` | Execute `setup_js` alongside `mute_js`, single page refresh |
| `tests/test_env.py` | Updated tests for new start_game() behavior (JS primary, ActionChains fallback) |
| `tests/test_game_plugins.py` | Added test for `setup_js` plugin attribute |

## Testing

- 707 tests pass, 96% coverage, 12 skipped
- All 4 CI jobs pass (Lint, Test, Build Check, Build Docs)