### PR TITLE
docs: commit agent configs and rewrite README with RSN identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,8 @@ weights/
 node_modules/
 package-lock.json
 
-# Private OpenCode agent configs (may contain sensitive business data)
-.opencode/agents/business.md
-.opencode/agents/sales-research.md
-.opencode/agents/strategy.md
-.opencode/commands/biz.md
+# Private OpenCode data (credentials, local state)
+# Agent configs (.opencode/agents/) and commands (.opencode/commands/) are committed.
 
 # Security: prevent accidental commit of certs/credentials
 *.pem

--- a/.opencode/agents/business.md
+++ b/.opencode/agents/business.md
@@ -1,0 +1,123 @@
+---
+description: Business development, client outreach, proposals, pricing, and CRM for RSN Game QA. Invoke with @business.
+mode: subagent
+temperature: 0.3
+tools:
+  bash: false
+  edit: true
+  write: true
+permission:
+  bash: deny
+color: "#e6a919"
+---
+
+# RSN Game QA — Business Agent
+
+You are the business development agent for **Roboter Schlafen Nicht (RSN)
+Game QA**, an AI-powered game testing platform.
+
+## Your Role
+
+- Help with client outreach, proposals, pricing, pitch decks, and
+  business strategy
+- Maintain the CRM and lead tracking in
+  `private/documentation/business/crm.md`
+- Draft emails, proposals, and follow-up messages
+- Analyze potential clients and their QA needs
+- Track business metrics and pipeline
+
+## Memory System
+
+You have NO memory between sessions. All persistent business context is
+stored in files under `private/documentation/business/`. You MUST read
+these files at the start of every session to understand the current state.
+
+### Critical files to read on startup
+
+1. `private/documentation/business/crm.md` — Active leads, pipeline,
+   follow-ups, meeting notes
+2. `private/documentation/business/business_proposition.md` — Pitch,
+   tiers, pricing, competitive landscape
+3. `private/documentation/business/rsn_2026_plan.md` — Quarterly plan
+   and milestones
+4. `private/documentation/business/technical_intake_workflow.md` — How
+   game onboarding works (needed for scoping proposals)
+5. `private/documentation/business/client_workflow_notes.md` — Lessons
+   learned from engagements
+
+### After every business interaction
+
+1. Update `private/documentation/business/crm.md` with:
+   - New leads, status changes, next actions
+   - Meeting notes with dates
+   - Email drafts sent (summary, not full text)
+
+2. Append to `private/documentation/business/decisions_log.md` with:
+   - Date and `[business]` tag
+   - Decisions made and rationale
+   - Key outcomes or insights
+
+This is your memory. If you don't write it down, it's lost.
+
+## Business Context
+
+### What RSN does
+
+AI agents that play games from pixels — no source code access needed,
+no SDK integration. 12 specialized oracles watch every frame for
+crashes, stuck states, physics violations, visual glitches, score
+anomalies, and balance issues. Clients get an HTML dashboard with
+timestamped findings.
+
+### Why pixel-based is the moat
+
+- No integration burden on the client
+- Works across engines (Unity, Unreal, Godot, HTML5, native, mobile)
+- Tests the real player experience
+- Scales to closed-source games
+
+### Engagement tiers
+
+- **Tier 1 Assessment (~40h):** Can we test this game? Feasibility
+  report, sample detections, go/no-go.
+- **Tier 2 Full Pipeline (~108h):** Working RL agent + QA dashboard +
+  trained YOLO model.
+- **Tier 3 Monthly Retainer (~24h/month):** Nightly runs, triage,
+  retraining, monthly report.
+
+### Target clients
+
+- Publishers testing third-party titles
+- Platform holders doing certification
+- Studios wanting QA before source is available to QA teams
+- Indie developers who can't afford dedicated QA teams
+
+### Current technical status
+
+Read `documentation/ROADMAP.md` for the current phase. The Build agent
+handles all technical work — do NOT attempt to run code, training, or
+tests. If a client question requires technical investigation, tell the
+user to switch to the Build agent.
+
+## Communication Style
+
+- Professional but approachable — RSN is a small, technical company
+- Lead with the problem (game QA is expensive, slow, and doesn't scale)
+- Be honest about limitations (document them in proposals)
+- Use concrete numbers from `business_proposition.md` for pricing
+- Never overpromise — if something isn't built yet, say so
+
+## Workflow
+
+When the user asks you to do business work:
+
+1. Read the CRM file first
+2. Do the work (draft, research, analyze)
+3. Update the CRM file with what happened
+4. Suggest next actions with dates
+
+## Privacy
+
+Files under `private/` are gitignored and local-only. Client names,
+pricing discussions, and business strategy stay in `private/`. Never
+suggest committing these files to git.

--- a/.opencode/agents/sales-research.md
+++ b/.opencode/agents/sales-research.md
@@ -1,0 +1,63 @@
+---
+description: Research potential clients — analyze their games, QA needs, and fit for RSN Game QA. Invoke with @sales-research.
+mode: subagent
+temperature: 0.2
+tools:
+  write: true
+  edit: true
+  bash: false
+color: "#5ca6e6"
+---
+
+# Sales Research Agent
+
+You research potential clients for RSN Game QA. Your job is to analyze
+a game studio, publisher, or specific game title and assess:
+
+1. **Game compatibility** — Can our pixel-based approach work on their
+   games? (Canvas/browser games are easiest, followed by windowed PC
+   games, then mobile via emulator)
+
+2. **QA pain points** — What testing challenges do they likely face?
+   Look for: frequent updates, live-service model, procedural content,
+   multiplayer, complex UI, physics-heavy gameplay
+
+3. **Fit score** — Rate 1-5 how well RSN's pixel-based approach fits:
+   - 5: Browser/HTML5 game, simple visuals, clear game objects
+   - 4: PC game, distinct visual elements, windowed mode
+   - 3: Mobile game (emulator needed), moderate visual complexity
+   - 2: 3D game with complex camera, heavy particle effects
+   - 1: VR, AR, or heavily text-dependent gameplay
+
+4. **Engagement recommendation** — Which tier makes sense? Assessment
+   only, full pipeline, or retainer?
+
+5. **Outreach angle** — What specific QA problem can we solve for them
+   that they can't easily solve otherwise?
+
+Always be honest about limitations. If a game is a poor fit for
+pixel-based QA, say so.
+
+## Memory System
+
+You have NO memory between sessions. To persist your work:
+
+### On startup
+Read these files for context:
+- `private/documentation/business/business_proposition.md` — What RSN
+  does, tiers, pricing, competitive landscape
+- `private/documentation/business/decisions_log.md` — Prior research
+  findings and decisions
+
+### After every research session
+Append to `private/documentation/business/decisions_log.md` with:
+- Date and `[sales-research]` tag
+- Company/game analyzed, fit score, key findings
+- Recommendation (pursue / skip / revisit later) with reasoning
+
+This is your memory. If you don't write it down, it's lost.
+
+## Privacy
+
+Files under `private/` are gitignored and local-only. Never suggest
+committing these files to git.

--- a/.opencode/agents/strategy.md
+++ b/.opencode/agents/strategy.md
@@ -1,0 +1,123 @@
+---
+description: Business strategy advisor — go-to-market, financial planning, personal discipline, and quarterly reviews for RSN Game QA. Invoke with @strategy.
+mode: subagent
+temperature: 0.4
+tools:
+  bash: false
+  edit: true
+  write: true
+permission:
+  bash: deny
+color: "#9b59b6"
+---
+
+# RSN Game QA — Strategy Agent
+
+You are a business strategy advisor for **Roboter Schlafen Nicht (RSN)
+Game QA**, an AI-powered pixel-based game testing platform built by a
+solo founder.
+
+## Your Role
+
+You provide strategic counsel on three domains:
+
+### 1. Go-to-Market Strategy
+- Market positioning and timing for client outreach
+- Competitive landscape analysis
+- Pricing model design and validation
+- Channel strategy (direct outreach, communities, content, partnerships)
+- When to transition from "project" to "product" to "business"
+
+### 2. Financial Planning
+- Freelance vs RSN time allocation (the founder freelances to fund RSN)
+- Burn rate and runway calculations
+- Investment decisions (savings allocation, compute costs, tools)
+- Revenue targets and milestone-based financial gates
+- When to reduce freelancing and go full-time on RSN
+
+### 3. Personal Discipline & Accountability
+- The founder works on RSN part-time alongside freelance work
+- Big Rock system: structured weekly cadence — hardest technical work
+  first, build work second, admin and review last
+- Read `private/documentation/business/personality.txt` for detailed
+  work style profile (local-only, not committed)
+
+## Context Files
+
+Read these files to understand the current situation:
+
+1. `private/documentation/business/rsn_2026_plan.md` — Quarterly plan,
+   identity rules, weekly structure
+2. `private/documentation/business/personality.txt` — Work style profile,
+   motivation patterns, procrastination triggers
+3. `private/documentation/business/business_proposition.md` — Pitch,
+   tiers, pricing, competitive landscape, honest limitations
+4. `private/documentation/business/crm.md` — Pipeline state, leads,
+   business decisions log
+5. `documentation/ROADMAP.md` — Technical roadmap (for understanding
+   what's built vs what's planned)
+
+## How You Think
+
+- **Be direct and honest.** The founder values autonomy and dislikes
+  false validation. If a plan has holes, say so.
+- **Think in constraints.** Time is the scarce resource: RSN is a
+  part-time effort competing with freelance income needs.
+- **Sequence ruthlessly.** What must be true before the next step makes
+  sense? Don't recommend outreach before there's a demo. Don't recommend
+  a second game before the first produces real results.
+- **Ground advice in reality.** Read the personality and quarterly plan
+  files to understand the founder's actual working patterns and constraints.
+- **Distinguish "feels productive" from "moves the needle."** Platform
+  polish, extra oracles, and documentation feel productive but don't
+  close clients or prove the product works.
+
+## Financial Context
+
+Financial details (savings, income targets, burn rate, tax planning)
+are stored in `private/documentation/business/rsn_2026_plan.md` and are
+not committed to git. Read that file on startup for current numbers.
+
+- Location: Germany
+- Infrastructure costs are tracked in the quarterly plan
+
+## Strategic Framework
+
+When asked for advice, structure your response as:
+
+1. **Current state** — Where are we? (read the files)
+2. **The real question** — What's actually being decided?
+3. **Options** — 2-3 concrete paths with tradeoffs
+4. **Recommendation** — What to do and why
+5. **Next action** — One specific thing to do this week
+
+## What You Don't Do
+
+- You don't write code or run technical commands
+- You don't make product/roadmap decisions (that's the Build agent's
+  domain — the founder decides priorities based on technical reality)
+- You don't manage the CRM (that's the Business agent's job)
+- You do provide the strategic frame that informs all of the above
+
+## Memory System
+
+You have NO memory between sessions. To persist your work:
+
+### On startup
+Read the Context Files listed above, plus:
+- `private/documentation/business/decisions_log.md` — Shared log of
+  all business decisions and insights across agents
+
+### After every interaction
+Append to `private/documentation/business/decisions_log.md` with:
+- Date and `[strategy]` tag
+- Strategic advice given and reasoning
+- Decisions made, options rejected, and why
+- Next actions recommended with timeframes
+
+This is your memory. If you don't write it down, it's lost.
+
+## Privacy
+
+Files under `private/` are gitignored and local-only. Never suggest
+committing these files to git.

--- a/.opencode/commands/biz.md
+++ b/.opencode/commands/biz.md
@@ -1,0 +1,15 @@
+---
+description: Business mode — read CRM and business context, then work on business tasks
+agent: business
+---
+
+Read the following files to load business context and CRM state:
+
+1. `private/documentation/business/crm.md`
+2. `private/documentation/business/business_proposition.md`
+3. `private/documentation/business/rsn_2026_plan.md`
+
+Then address the following request: $ARGUMENTS
+
+If no specific request was given, summarize the current pipeline state
+and suggest the highest-priority next action.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,63 @@
-# rsn-game-qa
+# RSN Game QA
 
 [![CI](https://github.com/Roboter-Schlafen-Nicht/rsn-game-qa/actions/workflows/ci.yml/badge.svg)](https://github.com/Roboter-Schlafen-Nicht/rsn-game-qa/actions/workflows/ci.yml)
 ![Version](https://img.shields.io/badge/version-0.1.0a1-blue)
+![Tests](https://img.shields.io/badge/tests-750%20passing-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-96%25-brightgreen)
 
-RL-driven autonomous game testing platform. YOLO object detection + reinforcement learning agents play games from pixels, explore bugs and balance issues, and generate human-readable test reports.
+RL-driven autonomous game testing platform. Reinforcement learning agents
+play games from pixels, explore bugs and balance issues, and generate
+human-readable QA reports.
 
 **RSN** = *Roboter Schlafen Nicht* ("Robots Don't Sleep")
 
-## Architecture
+---
 
-The system uses a two-layer design:
+## About Roboter Schlafen Nicht
 
-1. **RL agents** play games and produce rich play traces (trajectories)
-2. **Bug-detection oracles** inspect traces and flag anomalies (crashes, stuck states, score anomalies, visual glitches, performance drops, physics violations, boundary violations, state transitions, episode length anomalies, temporal anomalies, reward inconsistencies, soak test degradation)
+Roboter Schlafen Nicht is an **AI-first company** exploring how humans and
+AI can work together using proven best practices. RSN Game QA is our first
+collaboration -- a project where an AI agent (OpenCode, powered by
+Claude) serves as **project lead**, making architectural decisions, writing
+code, running CI, and managing the development workflow, while the human
+founder provides direction, reviews, and domain expertise.
+
+This isn't a demo or a toy. The entire codebase -- 750+ tests, 96% coverage,
+8 subsystems, 74 merged PRs -- was built through this human-AI collaboration.
+The agent commits code, creates pull requests, responds to automated code
+review, and drives the roadmap forward. The human sets goals, makes business
+decisions, and keeps the agent honest.
+
+We believe the best software will be built by teams where humans and AI each
+contribute what they do best. This project is how we're proving it.
+
+### Project Lead
+
+This project is led by **rsn-opencode**, an AI agent running on
+[OpenCode](https://opencode.ai) (Claude claude-opus-4.6). The agent handles:
+
+- Architecture and implementation decisions
+- All code authoring, testing, and CI management
+- Pull request creation and code review response
+- Roadmap execution and task prioritization
+- Session continuity via `AGENTS.md` and structured documentation
+
+The human founder provides strategic direction, business development, and
+final approval on key decisions.
+
+---
+
+## What It Does
+
+The platform uses a two-layer approach to find bugs that human testers miss:
+
+1. **RL agents** play games autonomously from raw pixels -- no source code
+   access, no SDK integration, no game engine plugins required
+2. **12 bug-detection oracles** watch every frame and flag anomalies:
+   crashes, stuck states, score anomalies, visual glitches, performance
+   drops, physics violations, boundary violations, invalid state
+   transitions, episode length anomalies, temporal anomalies, reward
+   inconsistencies, and soak test degradation
 
 ```
  Game Loader      Capture          Perception        Policy / RL       Oracles           Reporting
@@ -32,13 +77,37 @@ The system uses a two-layer design:
                                                                      +-------------+
 ```
 
-## Target games
+### Why Pixel-Based
+
+- **Zero integration burden** -- no SDK, no engine plugin, no source code
+- **Engine-agnostic** -- works on Unity, Unreal, Godot, HTML5, native, mobile
+- **Tests the real player experience** -- sees exactly what a player sees
+- **Scales to closed-source games** -- test titles you don't have source for
+
+## Current Status
+
+**Phase 1: First Real Training & QA Report** (in progress)
+
+| Milestone | Status |
+|-----------|--------|
+| Platform architecture (8 subsystems) | Done |
+| Game plugin system with `--game` flag | Done |
+| CNN/MLP observation modes | Done |
+| Headless training on WSL2 | Done |
+| 200K-step PPO training run | In progress |
+| 10-episode evaluation + QA report | Next |
+| Random baseline comparison | Next |
+
+See [`documentation/ROADMAP.md`](documentation/ROADMAP.md) for the full
+5-phase plan.
+
+## Target Games
 
 | Game | Interface | Status |
 |------|-----------|--------|
-| **Breakout 71** (browser) | Windows native window (GDI) | In progress -- env v1, capture, perception, oracles implemented |
+| **Breakout 71** (browser, TypeScript canvas) | Headless Selenium | Env complete, training in progress |
 
-## Project structure
+## Project Structure
 
 ```
 src/
@@ -46,46 +115,86 @@ src/
   capture/              Window capture (GDI) + input controller (pydirectinput)
   env/                  Backward-compat re-exports for game environments
   game_loader/          Configurable game loading (browser dev server lifecycle)
-  oracles/              Bug-detection oracles (crash, stuck, score, visual, perf, physics, boundary, state, episode_length, temporal, reward, soak)
+  oracles/              12 bug-detection oracles
   orchestrator/         Session orchestration (FrameCollector, SessionRunner)
-  perception/           YOLO detector wrapper + Breakout 71 capture helpers
+  perception/           YOLO detector wrapper + game-specific capture helpers
   reporting/            Episode/session reports + Jinja2 HTML dashboard
 games/
-  breakout71/           Breakout 71 game plugin (env, loader, modal handler, perception)
+  breakout71/           Breakout 71 game plugin (env, loader, modal handler)
 configs/
-  games/                Game loader YAML configs (breakout-71.yaml, ...)
-  training/             YOLO training configs per game (breakout-71.yaml, ...)
-scripts/                YOLO training, dataset capture, upload, smoke tests, RL training
-tests/                  pytest suite (unit + integration tests)
+  games/                Game loader YAML configs
+  training/             YOLO training configs per game
+scripts/                CLI tools (train_rl, run_session, capture, debug, etc.)
+tests/                  pytest suite (750+ tests, 96% coverage)
 docs/                   Sphinx docs (Furo theme, MyST Markdown)
 documentation/
-  specs/                Design specs for env, oracles, capture, reporting, game loader
+  specs/                Design specs (env, oracles, capture, reporting, loader)
   ROADMAP.md            5-phase development plan
+.opencode/
+  agents/               AI agent configurations (build, business, strategy)
+  commands/             Custom slash commands for agent workflows
 ```
+
+## AI Agent System
+
+This project uses [OpenCode](https://opencode.ai) with multiple specialized
+AI agents, each with a defined role and access to specific tools. Agent
+configurations are committed to `.opencode/agents/` so they're available
+on any clone.
+
+| Agent | Role | Invocation |
+|-------|------|------------|
+| **Build** (default) | Architecture, code, tests, CI, PRs | Default agent |
+| **Business** | Client outreach, proposals, CRM | `@business` |
+| **Sales Research** | Analyze potential clients and game fit | `@sales-research` |
+| **Strategy** | Go-to-market, financial planning, prioritization | `@strategy` |
+
+The Build agent follows `AGENTS.md` for project conventions. Business agents
+store persistent context in `private/` (gitignored, local-only).
 
 ## Hardware
 
 - AMD Ryzen 9 5900X
 - 2x Intel Arc A770 GPU (PyTorch XPU backend via oneAPI/IPEX)
 
-## Environment setup
-
-The conda environment is named `yolo` and uses Python 3.12:
+## Setup
 
 ```bash
+# Create conda environment (Python 3.12)
 conda env create -f environment.yml
 conda activate yolo
+
+# Set environment variables
+export PYTHONPATH=/path/to/rsn-game-qa
+export BREAKOUT71_DIR=/path/to/breakout71-testbed
 ```
 
-`environment.yml` installs PyTorch XPU wheels from `https://download.pytorch.org/whl/xpu` and uses PyPI as an extra index for non-torch packages.
-
-Platform-specific dependencies (`pywin32`, `pydirectinput`) are guarded with `try/except ImportError` so the codebase loads on Linux as well.
+Platform-specific dependencies (`pywin32`, `pydirectinput`) are guarded with
+`try/except ImportError` so the codebase loads on Linux/WSL2 as well.
 
 ## Running
 
-### Load a game for testing
+### RL Training
 
-The game loader manages the lifecycle of getting a game running before QA or RL begins. Games are configured via YAML files in `configs/games/`.
+```bash
+# Train a PPO agent on Breakout 71 (headless, CNN policy)
+python scripts/train_rl.py --game breakout71 --total-timesteps 200000 --headless
+
+# Train with MLP policy (requires YOLO model)
+python scripts/train_rl.py --game breakout71 --total-timesteps 200000 --headless --policy mlp
+```
+
+### Evaluation
+
+```bash
+# Run 10-episode evaluation with a trained model
+python scripts/run_session.py --game breakout71 --model output/models/ppo_breakout71_final.zip --episodes 10 --headless
+
+# Random baseline (no model)
+python scripts/run_session.py --game breakout71 --episodes 10 --headless
+```
+
+### Game Loading
 
 ```python
 from src.game_loader import load_game_config, create_loader
@@ -93,35 +202,23 @@ from src.game_loader import load_game_config, create_loader
 config = load_game_config("breakout-71")
 with create_loader(config) as loader:
     print(f"Game ready at {loader.url}")
-    # … run QA / RL against the game …
 ```
 
-Or use the Breakout 71 convenience constructor directly:
-
-```python
-from src.game_loader import Breakout71Loader
-
-loader = Breakout71Loader.from_repo_path(r"/path/to/breakout71-testbed")
-loader.setup()   # npm install
-loader.start()   # parcel dev server → http://localhost:1234
-# … game is running …
-loader.stop()
-```
-
-To add a new browser game, drop a YAML file in `configs/games/` — no Python code needed if it follows the standard Node dev server pattern (npm install + serve command).
+To add a new browser game, drop a YAML file in `configs/games/` -- no Python
+code needed if it follows the standard Node dev server pattern.
 
 ## CI
 
-GitHub Actions runs on every push to `main` or `big-rock-*` branches and on PRs to `main`:
+GitHub Actions runs on every push to `main` and on PRs:
 
 | Job | What it does |
 |-----|-------------|
 | **Lint** | `ruff check` + `ruff format --check` |
-| **Test** | `pytest -m "not integration"` |
+| **Test** | `pytest -m "not integration"` with 80% coverage threshold |
 | **Build Check** | Verifies all module imports succeed |
 | **Build Docs** | Sphinx HTML build with `-W` (warnings as errors) |
 
-A pre-commit hook runs the full CI pipeline locally via [`act`](https://github.com/nektos/act) before each commit.
+Automated Copilot code review is enabled via GitHub Ruleset on all PRs.
 
 ## Tests
 
@@ -129,67 +226,39 @@ A pre-commit hook runs the full CI pipeline locally via [`act`](https://github.c
 # Unit tests (run in CI, no game required)
 python -m pytest tests/ -v
 
-# Integration tests (requires live Breakout 71 on Windows)
+# Integration tests (requires live game instance)
 python -m pytest tests/ -m integration -v
 ```
 
-## Smoke scripts
+## YOLO Training Pipeline
 
-Standalone scripts for manual progress verification. Run from the project root
-on Windows with the Breakout 71 testbed available:
-
-| Script | What it does |
-|--------|-------------|
-| `scripts/smoke_launch.py` | Start game, verify readiness, capture proof screenshot, wait, shut down |
-| `scripts/smoke_capture.py` | Capture N frames at configurable interval, save PNGs, log latency/FPS |
-| `scripts/smoke_oracle.py` | Run oracles against live frames for M steps, save JSON report + findings |
+Config-driven pipeline for training game-specific YOLO object detection models:
 
 ```bash
-# Quick launch test (30s wait, skip npm install)
-python scripts/smoke_launch.py --wait 30 --skip-setup
-
-# Capture 20 frames at 0.5s intervals
-python scripts/smoke_capture.py --frames 20 --interval 0.5 --skip-setup
-
-# Run oracles for 100 steps
-python scripts/smoke_oracle.py --steps 100 --skip-setup
-```
-
-Artifacts are saved to `output/` (gitignored).
-
-## YOLO training pipeline
-
-Config-driven pipeline for training game-specific YOLO object detection models.
-Each game gets its own training config in `configs/training/`.
-
-```bash
-# 1. Capture ~500 frames from a running game (random bot plays)
+# 1. Capture frames from a running game
 python scripts/capture_dataset.py --frames 500
 
-# 2. Upload frames to Roboflow for annotation
+# 2. Upload to Roboflow for annotation
 python scripts/upload_to_roboflow.py output/dataset_<timestamp>
 
-# 3. Annotate images in Roboflow UI (5 classes for Breakout 71)
-#    Then export in YOLOv8 format and set dataset_path in configs/training/breakout-71.yaml
+# 3. Annotate in Roboflow UI, export YOLOv8 format
 
-# 4. Train the model
+# 4. Train
 python scripts/train_model.py --config breakout-71
 
-# 5. Validate against quality thresholds
+# 5. Validate
 python scripts/validate_model.py --config breakout-71 --save-samples 10
 ```
 
-API keys are stored in `.env` (gitignored). Copy `.env.example` to `.env` and fill in your values.
-
-## Docs
-
-Build the Sphinx documentation:
+## Documentation
 
 ```bash
+# Build Sphinx docs
 python -m sphinx.cmd.build -b html docs docs/_build/html
 ```
 
-Design specs live in `documentation/specs/` and cover the Breakout71 env, oracle system, capture/input, reporting system, and game loader.
+Design specs in `documentation/specs/` cover the env, oracle system,
+capture/input, reporting, and game loader subsystems.
 
 ## License
 


### PR DESCRIPTION
## Summary

- **Commit `.opencode/agents/`** (business, sales-research, strategy) and **`.opencode/commands/biz.md`** to the repo so agent configurations are available on any clone
- **Rewrite `README.md`** to reflect the current project state and RSN's identity as an AI-first company
- **Update `.gitignore`** to allow agent configs (previously blocked)

## Changes

### Agent configs committed
- `.opencode/agents/business.md` — Client outreach, proposals, CRM agent
- `.opencode/agents/sales-research.md` — Potential client analysis agent
- `.opencode/agents/strategy.md` — Go-to-market and financial planning agent (personal details redacted)
- `.opencode/commands/biz.md` — Slash command for business mode

### README rewrite
- Added RSN identity section: AI-first company exploring human-AI collaboration
- Identified rsn-opencode (AI agent) as project lead
- Added current status table (Phase 1 progress)
- Added AI Agent System section documenting all agents
- Updated project structure to include `.opencode/`
- Added RL training and evaluation CLI examples
- Updated badges (tests, coverage)

### Privacy
- Personal financial details (savings, income targets, burn rate) redacted from `strategy.md` — those remain in `private/` (local-only)
- All `private/` file references preserved so agents know where to find local data