### PR TITLE
fix: make alert dismissal resilient to multiple JS alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ package-lock.json
 # Private OpenCode data (credentials, local state)
 # Agent configs (.opencode/agents/) and commands (.opencode/commands/) are committed.
 
+# OpenCode project config (contains local paths, not for repo)
+opencode.json
+
 # Security: prevent accidental commit of certs/credentials
 *.pem
 *.key

--- a/scripts/autonomous.sh
+++ b/scripts/autonomous.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# scripts/autonomous.sh — Run OpenCode in continuous autonomous mode
+#
+# Usage:
+#   ./scripts/autonomous.sh              # new session
+#   ./scripts/autonomous.sh --continue   # continue last session
+#   ./scripts/autonomous.sh --session ID # continue specific session
+#
+# Stop: Ctrl+C (waits for current iteration to finish gracefully)
+#
+# Environment:
+#   LOOP_DELAY   — seconds between iterations (default: 10)
+#   MAX_ITERS    — max iterations, 0 = infinite (default: 0)
+#   OPENCODE_BIN — path to opencode binary (default: opencode)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# --- Config ---
+LOOP_DELAY="${LOOP_DELAY:-10}"
+MAX_ITERS="${MAX_ITERS:-0}"
+OPENCODE_BIN="${OPENCODE_BIN:-opencode}"
+LOG_DIR="${PROJECT_DIR}/output/autonomous_logs"
+mkdir -p "$LOG_DIR"
+
+# --- Session handling ---
+SESSION_FLAG=""
+CONTINUE_FLAG=""
+if [[ "${1:-}" == "--continue" || "${1:-}" == "-c" ]]; then
+    CONTINUE_FLAG="--continue"
+    shift || true
+elif [[ "${1:-}" == "--session" || "${1:-}" == "-s" ]]; then
+    shift
+    SESSION_FLAG="--session ${1:-}"
+    shift || true
+fi
+
+# --- Prompt ---
+# The agent reads AGENTS.md on every iteration, which contains full
+# instructions for autonomous operation. This prompt just kicks it off.
+PROMPT='You are running in autonomous continuous mode. Read AGENTS.md for your full instructions and current state. Then:
+
+1. Run `git status` and `git log --oneline -5` to orient
+2. Check `documentation/ROADMAP.md` for current phase
+3. Check `private/documentation/BigRocks/checklist.md` for task status
+4. Check for running training: `ps aux | grep train_rl`
+5. Pick the next incomplete task and execute it fully
+6. When done, summarize what you accomplished
+
+Do NOT ask for user input. Execute autonomously. You have full permissions.'
+
+# --- Trap Ctrl+C ---
+RUNNING=true
+trap 'echo -e "\n[autonomous] Caught SIGINT — finishing after current iteration..."; RUNNING=false' INT
+
+# --- Main loop ---
+ITER=0
+LOGFILE="$LOG_DIR/autonomous_$(date +%Y%m%d_%H%M%S).log"
+
+echo "=========================================="
+echo " OpenCode Autonomous Mode"
+echo "=========================================="
+echo " Project:    $PROJECT_DIR"
+echo " Log:        $LOGFILE"
+echo " Delay:      ${LOOP_DELAY}s between iterations"
+echo " Max iters:  $([ "$MAX_ITERS" -eq 0 ] && echo 'infinite' || echo "$MAX_ITERS")"
+echo " Session:    ${CONTINUE_FLAG:-${SESSION_FLAG:-new}}"
+echo "=========================================="
+echo ""
+
+{
+    echo "[$(date)] Autonomous mode started"
+    echo "[$(date)] Config: delay=${LOOP_DELAY}s max_iters=${MAX_ITERS}"
+} >> "$LOGFILE"
+
+while $RUNNING; do
+    ITER=$((ITER + 1))
+
+    if [[ "$MAX_ITERS" -gt 0 && "$ITER" -gt "$MAX_ITERS" ]]; then
+        echo "[autonomous] Reached max iterations ($MAX_ITERS). Stopping."
+        break
+    fi
+
+    echo ""
+    echo "--- Iteration $ITER | $(date) ---"
+    echo "[$(date)] === Iteration $ITER ===" >> "$LOGFILE"
+
+    # Build command
+    CMD=("$OPENCODE_BIN" "run")
+
+    # First iteration: use session flags if provided
+    # Subsequent iterations: always continue last session
+    if [[ "$ITER" -eq 1 ]]; then
+        if [[ -n "$CONTINUE_FLAG" ]]; then
+            CMD+=("$CONTINUE_FLAG")
+        elif [[ -n "$SESSION_FLAG" ]]; then
+            # shellcheck disable=SC2206
+            CMD+=($SESSION_FLAG)
+        fi
+    else
+        CMD+=("--continue")
+    fi
+
+    CMD+=("$PROMPT")
+
+    # Run opencode
+    echo "[autonomous] Running: ${CMD[*]:0:4}..."
+    if "${CMD[@]}" 2>&1 | tee -a "$LOGFILE"; then
+        echo "[$(date)] Iteration $ITER completed successfully" >> "$LOGFILE"
+    else
+        EXIT_CODE=$?
+        echo "[$(date)] Iteration $ITER exited with code $EXIT_CODE" >> "$LOGFILE"
+        echo "[autonomous] opencode exited with code $EXIT_CODE"
+
+        # If opencode crashes, wait longer before retry
+        if [[ "$EXIT_CODE" -ne 0 ]]; then
+            echo "[autonomous] Waiting 30s before retry..."
+            sleep 30
+        fi
+    fi
+
+    if $RUNNING; then
+        echo "[autonomous] Sleeping ${LOOP_DELAY}s before next iteration..."
+        sleep "$LOOP_DELAY"
+    fi
+done
+
+echo ""
+echo "[autonomous] Stopped after $ITER iterations."
+echo "[$(date)] Autonomous mode stopped after $ITER iterations" >> "$LOGFILE"

--- a/scripts/profile_capture.py
+++ b/scripts/profile_capture.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Compare headless capture methods: Selenium PNG vs CDP JPEG vs canvas toDataURL."""
+
+import base64
+import logging
+import os
+import sys
+import time
+
+import numpy as np
+
+for name in ("selenium", "urllib3", "ultralytics", "openvino"):
+    logging.getLogger(name).setLevel(logging.WARNING)
+logging.basicConfig(level=logging.WARNING)
+
+sys.path.insert(0, os.environ.get("PYTHONPATH", "/mnt/f/work/rsn-game-qa"))
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+
+game_dir = os.environ.get("BREAKOUT71_DIR", "/mnt/f/work/breakout71-testbed")
+dist_index = os.path.join(game_dir, "dist", "index.html")
+
+options = Options()
+options.add_argument("--headless=new")
+options.add_argument("--no-sandbox")
+options.add_argument("--disable-dev-shm-usage")
+options.add_argument("--disable-gpu")
+options.add_argument("--window-size=500,900")
+options.add_argument("--mute-audio")
+
+service = Service()
+driver = webdriver.Chrome(service=service, options=options)
+driver.get(f"file://{dist_index}")
+time.sleep(2)
+
+import cv2
+
+N = 30
+
+# --- Method 1: Selenium get_screenshot_as_png ---
+times_png = []
+for _ in range(N):
+    t0 = time.perf_counter()
+    png_bytes = driver.get_screenshot_as_png()
+    nparr = np.frombuffer(png_bytes, np.uint8)
+    frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+    times_png.append(time.perf_counter() - t0)
+
+# --- Method 2: CDP Page.captureScreenshot (JPEG) ---
+times_cdp_jpeg = []
+for _ in range(N):
+    t0 = time.perf_counter()
+    result = driver.execute_cdp_cmd(
+        "Page.captureScreenshot",
+        {
+            "format": "jpeg",
+            "quality": 80,
+        },
+    )
+    img_bytes = base64.b64decode(result["data"])
+    nparr = np.frombuffer(img_bytes, np.uint8)
+    frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+    times_cdp_jpeg.append(time.perf_counter() - t0)
+
+# --- Method 3: CDP Page.captureScreenshot (PNG) ---
+times_cdp_png = []
+for _ in range(N):
+    t0 = time.perf_counter()
+    result = driver.execute_cdp_cmd(
+        "Page.captureScreenshot",
+        {
+            "format": "png",
+        },
+    )
+    img_bytes = base64.b64decode(result["data"])
+    nparr = np.frombuffer(img_bytes, np.uint8)
+    frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+    times_cdp_png.append(time.perf_counter() - t0)
+
+# --- Method 4: canvas.toDataURL (JPEG) ---
+times_canvas = []
+for _ in range(N):
+    t0 = time.perf_counter()
+    data_url = driver.execute_script(
+        "return document.getElementById('game').toDataURL('image/jpeg', 0.8);"
+    )
+    # data:image/jpeg;base64,...
+    b64_data = data_url.split(",", 1)[1]
+    img_bytes = base64.b64decode(b64_data)
+    nparr = np.frombuffer(img_bytes, np.uint8)
+    frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+    times_canvas.append(time.perf_counter() - t0)
+
+# --- Method 5: canvas.toDataURL (PNG) ---
+times_canvas_png = []
+for _ in range(N):
+    t0 = time.perf_counter()
+    data_url = driver.execute_script(
+        "return document.getElementById('game').toDataURL('image/png');"
+    )
+    b64_data = data_url.split(",", 1)[1]
+    img_bytes = base64.b64decode(b64_data)
+    nparr = np.frombuffer(img_bytes, np.uint8)
+    frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+    times_canvas_png.append(time.perf_counter() - t0)
+
+driver.quit()
+
+print(f"\n{'=' * 60}")
+print(f"Capture method comparison ({N} frames each)")
+print(f"{'=' * 60}")
+for name, times in [
+    ("Selenium PNG", times_png),
+    ("CDP JPEG (q=80)", times_cdp_jpeg),
+    ("CDP PNG", times_cdp_png),
+    ("Canvas toDataURL JPEG", times_canvas),
+    ("Canvas toDataURL PNG", times_canvas_png),
+]:
+    arr = np.array(times) * 1000
+    print(
+        f"  {name:25s}: {np.mean(arr):6.1f}ms ± {np.std(arr):4.1f}ms  (FPS: {1000 / np.mean(arr):5.1f})"
+    )

--- a/scripts/profile_step.py
+++ b/scripts/profile_step.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Profile individual components of the step() loop.
+
+Instruments apply_action, _capture_frame, _detect_objects,
+build_observation, _check_late_game_over, check_termination,
+compute_reward, _make_info, and _run_oracles individually.
+"""
+
+import logging
+import os
+import sys
+import time
+
+import numpy as np
+
+# Silence noisy loggers
+for name in (
+    "selenium",
+    "urllib3",
+    "ultralytics",
+    "httpcore",
+    "httpx",
+    "PIL",
+    "onnxruntime",
+    "openvino",
+):
+    logging.getLogger(name).setLevel(logging.WARNING)
+
+logging.basicConfig(level=logging.WARNING)
+
+sys.path.insert(0, os.environ.get("PYTHONPATH", "/mnt/f/work/rsn-game-qa"))
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+
+# -- Setup browser --
+game_dir = os.environ.get("BREAKOUT71_DIR", "/mnt/f/work/breakout71-testbed")
+dist_index = os.path.join(game_dir, "dist", "index.html")
+
+options = Options()
+options.add_argument("--headless=new")
+options.add_argument("--no-sandbox")
+options.add_argument("--disable-dev-shm-usage")
+options.add_argument("--disable-gpu")
+options.add_argument("--window-size=500,900")
+options.add_argument("--mute-audio")
+
+service = Service()
+driver = webdriver.Chrome(service=service, options=options)
+driver.get(f"file://{dist_index}")
+time.sleep(2)
+
+# -- Create env --
+from games.breakout71.env import Breakout71Env
+
+env = Breakout71Env(
+    window_title="Breakout",
+    yolo_weights="weights/breakout71/best.pt",
+    max_steps=10_000,
+    driver=driver,
+    device="auto",
+    headless=True,
+)
+
+print("Resetting env...")
+obs, info = env.reset()
+print(f"Reset done. obs shape: {obs.shape}")
+
+# -- Profile individual components --
+N = 50
+timings = {
+    "apply_action": [],
+    "should_check_modals": [],
+    "capture_frame": [],
+    "detect_objects": [],
+    "build_observation": [],
+    "check_late_game_over": [],
+    "check_termination": [],
+    "compute_reward": [],
+    "make_info": [],
+    "run_oracles": [],
+    "total_step": [],
+}
+
+for i in range(N):
+    action = env.action_space.sample()
+    step_start = time.perf_counter()
+
+    # 1. apply_action
+    t0 = time.perf_counter()
+    env.apply_action(action)
+    timings["apply_action"].append(time.perf_counter() - t0)
+
+    # 2. _should_check_modals
+    t0 = time.perf_counter()
+    should_check = env._should_check_modals()
+    timings["should_check_modals"].append(time.perf_counter() - t0)
+
+    # (skip actual modal check for profiling — it would change game state)
+    # In normal step, this only fires when _no_ball_count > 0
+
+    # 3. _capture_frame
+    t0 = time.perf_counter()
+    frame = env._capture_frame()
+    timings["capture_frame"].append(time.perf_counter() - t0)
+
+    # 4. _detect_objects
+    t0 = time.perf_counter()
+    detections = env._detect_objects(frame)
+    timings["detect_objects"].append(time.perf_counter() - t0)
+
+    # 5. build_observation
+    t0 = time.perf_counter()
+    obs = env.build_observation(detections)
+    timings["build_observation"].append(time.perf_counter() - t0)
+
+    # 6. _check_late_game_over
+    t0 = time.perf_counter()
+    late_go = env._check_late_game_over(detections)
+    timings["check_late_game_over"].append(time.perf_counter() - t0)
+
+    if late_go:
+        print(f"  Step {i}: late game over detected, stopping")
+        break
+
+    # 7. check_termination
+    t0 = time.perf_counter()
+    terminated, level_cleared = env.check_termination(detections)
+    timings["check_termination"].append(time.perf_counter() - t0)
+
+    # 8. compute_reward
+    t0 = time.perf_counter()
+    reward = env.compute_reward(detections, terminated, level_cleared)
+    timings["compute_reward"].append(time.perf_counter() - t0)
+
+    # 9. _make_info
+    t0 = time.perf_counter()
+    info_dict = env._make_info(detections)
+    timings["make_info"].append(time.perf_counter() - t0)
+
+    # 10. _run_oracles
+    t0 = time.perf_counter()
+    findings = env._run_oracles(obs, reward, terminated, False, info_dict)
+    timings["run_oracles"].append(time.perf_counter() - t0)
+
+    timings["total_step"].append(time.perf_counter() - step_start)
+
+    env._step_count += 1
+
+    if terminated:
+        print(f"  Step {i}: terminated (level_cleared={level_cleared})")
+        break
+
+# -- Print results --
+print(f"\n{'=' * 60}")
+print(f"Step profiling results ({len(timings['total_step'])} steps)")
+print(f"{'=' * 60}")
+
+total_mean = np.mean(timings["total_step"]) * 1000
+
+for key in [
+    "apply_action",
+    "should_check_modals",
+    "capture_frame",
+    "detect_objects",
+    "build_observation",
+    "check_late_game_over",
+    "check_termination",
+    "compute_reward",
+    "make_info",
+    "run_oracles",
+    "total_step",
+]:
+    vals = np.array(timings[key]) * 1000  # to ms
+    mean = np.mean(vals)
+    std = np.std(vals)
+    pct = (mean / total_mean * 100) if key != "total_step" else 100.0
+    print(f"  {key:25s}: {mean:7.1f}ms ± {std:5.1f}ms  ({pct:5.1f}%)")
+
+accounted = sum(np.mean(timings[k]) for k in timings if k != "total_step") * 1000
+unaccounted = total_mean - accounted
+print(f"\n  {'accounted':25s}: {accounted:7.1f}ms")
+print(f"  {'unaccounted (overhead)':25s}: {unaccounted:7.1f}ms")
+print(f"  {'FPS':25s}: {1000 / total_mean:7.1f}")
+
+# Cleanup
+env.close()
+driver.quit()
+print("\nDone.")


### PR DESCRIPTION
## Summary

- Extract `_dismiss_all_alerts()` helper that loops up to `max_attempts` (default 5) to clear all pending JS alerts, replacing single-dismiss code that crashed training at ~115K+ steps when the game spawned multiple simultaneous alerts
- Fall back to cached frame (`_last_frame`) instead of raising `RuntimeError` when all capture attempts fail — prevents training crash from transient browser issues
- Add profiling scripts (`profile_capture.py`, `profile_step.py`) and autonomous runner (`autonomous.sh`)
- Add `opencode.json` to `.gitignore`
- 7 new tests for `_dismiss_all_alerts` and headless capture resilience, 775 total tests passing, 96.22% coverage

## Context

Training run #3 (resuming from 50K checkpoint) crashed at ~115K+ steps with `UnexpectedAlertPresentException: Alert Text: Two alerts where opened at once`. The fix from PR #79 only dismissed a single alert; this PR handles the case where multiple alerts stack up.