### PR TITLE
feat: add --reward-mode survival for noise-free RL training

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,12 +82,11 @@ Environment variables used above (set in your shell profile):
 ### Current status (updated by agent)
 
 - **Phase:** 1 (First Real Training & QA Report)
-- **Training:** 100K/200K steps complete, checkpoint at
-  `output/checkpoints/ppo_breakout71_100001.zip`
-- **Crashes:** 2 (Chrome OOM at 57K, JS alert at 115K — both fixed)
-- **PR #79:** Alert handling fix — CI green, ready to merge
-- **Next:** Merge PR #79, resume training from 100K, run to 200K,
-  evaluate, generate QA report
+- **Training:** CNN policy 200K run in progress (started fresh, ~15 FPS)
+- **Crashes:** 3 (Chrome OOM at 57K, JS alert at 115K, multi-alert — all fixed)
+- **PR #82:** Multi-alert resilience + profiling scripts — merged
+- **Next:** Wait for CNN 200K training to complete (~3-4 hours),
+  evaluate, run random baseline, generate QA report
 
 ## Conventions
 
@@ -123,11 +122,11 @@ module where the behavioral contract matters more than implementation.
 
 ## Current State
 
-- **Tests pass**, 96% coverage, 8 subsystems complete
+- **Tests pass**, 96% coverage, 775 tests, 8 subsystems complete
 - **Architecture done:** BaseGameEnv ABC, game plugin system (`games/`),
   `--game` flag, CNN/MLP observation modes, dynamic plugin loading
-- **Phase 1 in progress** — 100K/200K training steps done, 2 crash bugs
-  fixed (Chrome OOM, JS alert), resuming training from checkpoint
+- **Phase 1 in progress** — 3 crash bugs fixed (Chrome OOM, JS alert,
+  multi-alert), CNN 200K training run in progress
 - **Human is OOO Feb 18–20, 2026** — agent operates fully autonomously
 - See `documentation/ROADMAP.md` for the 5-phase plan
 - See `private/documentation/BigRocks/checklist.md` for detailed task tracking

--- a/games/breakout71/env.py
+++ b/games/breakout71/env.py
@@ -137,6 +137,7 @@ class Breakout71Env(BaseGameEnv):
         driver: Optional[Any] = None,
         device: str = "auto",
         headless: bool = False,
+        reward_mode: str = "yolo",
     ) -> None:
         super().__init__(
             window_title=window_title,
@@ -147,6 +148,7 @@ class Breakout71Env(BaseGameEnv):
             driver=driver,
             device=device,
             headless=headless,
+            reward_mode=reward_mode,
         )
 
         # Observation: 8-element vector

--- a/scripts/run_session.py
+++ b/scripts/run_session.py
@@ -148,6 +148,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--reward-mode",
+        type=str,
+        default="yolo",
+        choices=["yolo", "survival"],
+        help=(
+            "Reward signal strategy.  'yolo' (default) uses game-specific "
+            "YOLO-based reward.  'survival' uses +0.01 per step, -5.0 on "
+            "game over, +5.0 on level clear."
+        ),
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -217,6 +228,7 @@ def main(argv: list[str] | None = None) -> int:
         headless=args.headless,
         policy=args.policy,
         frame_stack=args.frame_stack,
+        reward_mode=args.reward_mode,
     )
 
     report = runner.run()

--- a/scripts/train_rl.py
+++ b/scripts/train_rl.py
@@ -246,6 +246,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Number of frames to stack for CNN policy (default: 4)",
     )
 
+    # -- Reward mode -------------------------------------------------------
+    parser.add_argument(
+        "--reward-mode",
+        type=str,
+        default="survival",
+        choices=["yolo", "survival"],
+        help=(
+            "Reward signal strategy.  'yolo' uses YOLO-based brick/score "
+            "deltas (noisy).  'survival' uses +0.01 per step, -5.0 on game "
+            "over, +5.0 on level clear (clean gradient).  Default: survival."
+        ),
+    )
+
     # -- Resume from checkpoint --------------------------------------------
     parser.add_argument(
         "--resume",
@@ -852,6 +865,7 @@ def main(argv: list[str] | None = None) -> int:
                 "device": args.device,
                 "policy": args.policy,
                 "frame_stack": args.frame_stack,
+                "reward_mode": args.reward_mode,
                 "yolo_weights": yolo_weights,
                 "max_steps": args.max_steps,
                 "n_steps": args.n_steps,
@@ -886,6 +900,7 @@ def main(argv: list[str] | None = None) -> int:
             driver=browser_instance.driver,
             device=args.device,
             headless=args.headless,
+            reward_mode=args.reward_mode,
         )
 
         # -- Wrap for CNN policy (if requested) ----------------------------

--- a/src/orchestrator/session_runner.py
+++ b/src/orchestrator/session_runner.py
@@ -204,6 +204,10 @@ class SessionRunner:
     frame_stack : int
         Number of frames to stack when ``policy="cnn"``.  Default is 4.
         Ignored when ``policy="mlp"``.
+    reward_mode : str
+        Reward signal strategy passed to the environment.
+        ``"yolo"`` (default) uses game-specific YOLO-based reward.
+        ``"survival"`` uses ``+0.01`` per step, ``-5.0`` on game over.
     """
 
     def __init__(
@@ -221,6 +225,7 @@ class SessionRunner:
         headless: bool = False,
         policy: str = "mlp",
         frame_stack: int = 4,
+        reward_mode: str = "yolo",
     ) -> None:
         valid_policies = ("mlp", "cnn")
         if policy not in valid_policies:
@@ -240,6 +245,7 @@ class SessionRunner:
         self.headless = headless
         self.policy = policy
         self.frame_stack = frame_stack
+        self.reward_mode = reward_mode
 
         # Load plugin to resolve defaults
         from games import load_game_plugin
@@ -392,6 +398,7 @@ class SessionRunner:
             oracles=oracles,
             driver=self._browser_instance.driver,
             headless=self.headless,
+            reward_mode=self.reward_mode,
         )
 
         # Create frame collector

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -669,6 +669,25 @@ class TestComputeReward:
         assert abs(env._prev_bricks_norm - 0.7) < 1e-6
 
 
+class TestRewardModePassthrough:
+    """Verify Breakout71Env passes reward_mode to BaseGameEnv."""
+
+    def test_default_is_yolo(self):
+        """Default reward_mode is 'yolo'."""
+        env = Breakout71Env()
+        assert env.reward_mode == "yolo"
+
+    def test_survival_mode_passthrough(self):
+        """reward_mode='survival' is forwarded to BaseGameEnv."""
+        env = Breakout71Env(reward_mode="survival")
+        assert env.reward_mode == "survival"
+
+    def test_invalid_mode_raises(self):
+        """Invalid reward_mode raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid reward_mode"):
+            Breakout71Env(reward_mode="bogus")
+
+
 # -- Apply Action --------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Adds `--reward-mode` CLI flag (`yolo|survival`) to `train_rl.py` and `run_session.py`
- Implements survival reward at the platform level (`BaseGameEnv`): `+0.01` per step survived, `-5.0` on game over, `+5.0` on level clear
- Default for training is `survival` (clean gradient signal); default for eval is `yolo` (score-based metrics)

## Why

YOLO-based brick-counting reward is pathological for RL training — every episode was ~22 steps with uniform ~14.77 reward regardless of agent behavior. The reward signal is overwhelmed by detection noise (spurious brick_delta from YOLO false positives, modal occlusion creating bursts of false positive reward). The agent cannot distinguish good actions from bad.

Survival reward provides a clean, monotonic gradient: longer episodes are strictly better. This is the minimum viable reward signal needed for Phase 1 training.

## Changes

- `src/platform/base_env.py`: `reward_mode` param, `_VALID_REWARD_MODES`, `_compute_survival_reward()`, `_SURVIVAL_TERMINAL_REWARD` constant, survival overrides in all 3 `step()` exit paths
- `games/breakout71/env.py`: `reward_mode` param passthrough to `BaseGameEnv.__init__()`
- `scripts/train_rl.py`: `--reward-mode` flag (default: `survival`), JSONL config logging
- `scripts/run_session.py`: `--reward-mode` flag (default: `yolo`)
- `src/orchestrator/session_runner.py`: `reward_mode` param passthrough
- `tests/test_base_env.py`: 14 new tests (`TestRewardModeValidation` + `TestSurvivalReward`)
- `tests/test_env.py`: 3 new tests (`TestRewardModePassthrough`)

## Testing

- 791 tests pass, 96.21% coverage
- 17 new tests covering validation, reward computation, and passthrough