### PR TITLE
feat: integrate GameOverDetector into step() and reset() lifecycle

### DIFF
--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -1073,6 +1073,23 @@ class TestGameOverDetectorStepIntegration:
         assert reward == env._SURVIVAL_TERMINAL_REWARD
 
     @mock.patch("src.platform.base_env.time")
+    def test_step_applies_terminal_reward_on_detector_game_over_yolo_mode(
+        self, mock_time
+    ):
+        """When detector signals game-over in yolo mode, reward uses terminal_reward()."""
+        detector = mock.MagicMock()
+        detector.update.return_value = True
+        detector.get_confidence.return_value = {"screen_freeze": 0.9}
+        env = _make_ready_env(game_over_detector=detector)
+        assert env.reward_mode == "yolo"
+
+        obs, reward, terminated, truncated, info = env.step(_action())
+
+        assert terminated is True
+        assert reward == env.terminal_reward()
+        assert "game_over_detector" in info
+
+    @mock.patch("src.platform.base_env.time")
     def test_step_without_detector_behaves_normally(self, mock_time):
         """When no detector is provided, step() works as before."""
         env = _make_ready_env()  # no game_over_detector


### PR DESCRIPTION
## Summary

- Wire pixel-based game-over detection into `BaseGameEnv.step()` — calls `detector.update(frame)` after frame capture and terminates with terminal reward + confidence info when triggered
- Wire `detector.reset()` into `BaseGameEnv.reset()` to clear per-episode state
- Modal-based game-over still takes priority (early return before detector check)

## Details

Phase 3 task: integrate the `GameOverDetector` (merged in PR #91) into the `step()`/`reset()` lifecycle so pixel-based game-over detection is active during training.

### step() integration (line 518)
- After frame capture and observation building, calls `self._game_over_detector.update(frame)`
- When detector fires: increments step counter, computes terminal reward (survival or YOLO), adds `game_over_detector` confidence dict to info, runs oracles, returns `terminated=True`
- Placed BEFORE `_check_late_game_over()` so pixel-based detection fires before YOLO-dependent paths
- When `game_over_detector` is `None` (default), behavior is unchanged (backward compat)

### reset() integration (line 450)
- After `reset_termination_state()`, calls `self._game_over_detector.reset()` to clear per-episode state
- Guarded by `is not None` check for backward compat

### TDD
- 11 tests (8 step, 3 reset) following RED-GREEN-REFACTOR:
  - `TestGameOverDetectorStepIntegration`: update called with frame, terminates on True, does not terminate on False, applies terminal reward, backward compat, confidence in info, modal priority, oracles run
  - `TestGameOverDetectorResetIntegration`: reset called, backward compat, clean state after reset

## Test Results
- All 887 tests pass (15 skipped — pytesseract/wincam)
- 96.34% coverage
- CI passes (Lint, Test, Build Check, Build Docs)