### PR TITLE
fix: add get_confidence() method to GameOverDetector

### DIFF
--- a/src/platform/game_over_detector.py
+++ b/src/platform/game_over_detector.py
@@ -491,6 +491,19 @@ class GameOverDetector:
         """Return per-strategy confidence from the last update."""
         return dict(self._last_per_strategy)
 
+    def get_confidence(self) -> dict[str, float]:
+        """Return per-strategy confidence dict for info reporting.
+
+        Convenience method used by ``BaseGameEnv.step()`` to populate
+        the ``game_over_detector`` key in the info dict.
+
+        Returns
+        -------
+        dict[str, float]
+            Per-strategy confidence values from the last ``update()``.
+        """
+        return self.strategy_confidences
+
     def update(self, frame: np.ndarray) -> bool:
         """Process a frame and return whether game-over is detected.
 

--- a/tests/test_game_over_detector.py
+++ b/tests/test_game_over_detector.py
@@ -551,6 +551,18 @@ class TestGameOverDetector:
         assert freeze.name in sc
         assert isinstance(sc[freeze.name], float)
 
+    def test_get_confidence_returns_same_as_strategy_confidences(self):
+        """get_confidence() returns the same dict as strategy_confidences."""
+        from src.platform.game_over_detector import (
+            GameOverDetector,
+            ScreenFreezeStrategy,
+        )
+
+        freeze = ScreenFreezeStrategy()
+        detector = GameOverDetector(strategies=[freeze])
+        detector.update(_make_frame())
+        assert detector.get_confidence() == detector.strategy_confidences
+
     def test_weights_normalized_when_not_summing_to_one(self):
         """Weights are auto-normalized if they don't sum to 1.0."""
         from src.platform.game_over_detector import (


### PR DESCRIPTION
## Summary

- Add `get_confidence()` method to `GameOverDetector` — delegates to `strategy_confidences` property
- Fixes runtime `AttributeError` when `BaseGameEnv.step()` calls `self._game_over_detector.get_confidence()` on a real detector (tests used `MagicMock` which auto-creates missing methods, hiding the bug)
- Add test verifying `get_confidence()` returns same dict as `strategy_confidences`