### PR TITLE
docs: add hardware convention (Intel Arc XPU) to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ rationale, and business impact.
 
 ## Conventions
 
+- **Hardware:** Intel Arc GPU (XPU, not CUDA). `torch.xpu` for GPU,
+  SB3 PPO on CPU. See `agent_knowledge_base.md` for details.
 - Python 3.12, conda env `yolo`
 - NumPy-style docstrings
 - `ruff` for lint/format -- always run `ruff format` before committing


### PR DESCRIPTION
## Summary

- Adds a **Hardware** convention line to `AGENTS.md` Conventions section: Intel Arc GPU (XPU, not CUDA), `torch.xpu` for GPU, SB3 PPO on CPU
- References `agent_knowledge_base.md` for full hardware details

## Context

The hardware setup was previously scattered across session history that got removed during the AGENTS.md restructure (PR #100). This ensures the agent always knows the GPU type after compaction, without having to search the knowledge base.

The detailed Hardware Setup table was also added to `agent_knowledge_base.md` (private/gitignored, not in this diff).

## Files changed

| File | Change |
|------|--------|
| `AGENTS.md` | Added hardware convention bullet |