### PR TITLE
feat: multi-file support and top-episodes display in analyze_training

### DIFF
--- a/scripts/analyze_training.py
+++ b/scripts/analyze_training.py
@@ -438,7 +438,7 @@ def format_report(analysis: dict, *, top_episodes: int = 5) -> str:
                 f"RND={e['rnd_mean']:.6f}, {e['termination']}"
             )
         lines.append(f"Top {n} Shortest Episodes:")
-        for e in by_steps[-n:]:
+        for e in reversed(by_steps[-n:]):
             lines.append(
                 f"  Episode {e['episode']:>3}: {e['steps']:>6,} steps, "
                 f"RND={e['rnd_mean']:.6f}, {e['termination']}"

--- a/tests/test_analyze_training.py
+++ b/tests/test_analyze_training.py
@@ -601,7 +601,6 @@ class TestMain:
         # File 2: resumed training, 2 more episodes (no config, like a real resume)
         file2 = tmp_path / "log2.jsonl"
         events2 = [
-            _make_config_event(),
             _make_episode_event(2, 300, -1.0, "game_over", 0.002, 0.6),
             _make_episode_event(3, 2000, 3.5, "truncated", 0.00003, 0.06),
         ]


### PR DESCRIPTION
## Summary

- Accept multiple JSONL log files (`nargs='+'`) for analyzing resumed training runs that span multiple log files
- Wire `--top-episodes` CLI arg to `format_report()` — was accepted by argparse but never used in output
- Add longest/shortest episodes ranked section to console report
- 7 new tests (52 total for analyze_training module)

## Motivation

The current 200K training run (PID 53751) was resumed from a 50K checkpoint after a Chrome crash killed the prior run. This produced two JSONL log files that need to be analyzed together. The single-file limitation made combined analysis impossible without manual concatenation.

## Changes

### `scripts/analyze_training.py`
- `log_file` positional arg → `log_files` with `nargs='+'`
- Events from multiple files are concatenated in order
- `format_report()` accepts `top_episodes` kwarg, renders "Top N Longest/Shortest Episodes" section
- Updated docstring with multi-file usage example

### `tests/test_analyze_training.py`
- `test_top_episodes_arg` — strengthened to verify section headers appear
- `test_top_episodes_in_report` — verify custom top count
- `test_top_episodes_section` — format_report with kwarg
- `test_top_episodes_zero_suppressed` — top_episodes=0 hides section
- `test_top_episodes_capped_to_count` — fewer episodes than requested
- `test_multi_file_concatenation` — two files combined, 4 episodes total
- `test_multi_file_one_missing` — FileNotFoundError on missing file
- `test_multi_file_all_empty` — SystemExit when all files empty