### PR TITLE
fix: handle discrete action spaces in training callback logging

### DIFF
--- a/scripts/train_rl.py
+++ b/scripts/train_rl.py
@@ -635,9 +635,12 @@ class FrameCollectionCallback:
                     infos = self.locals.get("infos", [])
                     info = infos[0] if infos else {}
                     actions = self.locals.get("actions")
-                    action_val = (
-                        float(actions[0][0]) if actions is not None and len(actions) > 0 else None
-                    )
+                    action_val = None
+                    if actions is not None and len(actions) > 0:
+                        act = actions[0]
+                        # Continuous action spaces produce arrays; discrete
+                        # action spaces produce scalar integers/floats.
+                        action_val = float(act[0]) if hasattr(act, "__len__") else float(act)
                     paddle_pos = info.get("paddle_pos")
 
                     step_event = {


### PR DESCRIPTION
## Summary

- Fix `IndexError: invalid index to scalar variable` crash in `FrameCollectionCallback` when training with `Discrete` action spaces (e.g., Hextris)
- The callback assumed actions are always 2D arrays (`actions[0][0]`), which is true for continuous `Box` spaces but not for `Discrete` spaces where `actions[0]` is a scalar integer

## Changes

- `scripts/train_rl.py`: Use `hasattr(act, "__len__")` to distinguish scalar (Discrete) vs array (Box) actions before indexing

## Testing

- All 1137 tests pass, 94.98% coverage
- Verified fix resolves the crash that killed the first Hextris training attempt

## Context

This bug was discovered when launching the first CNN training run on Hextris (`Discrete(3)` action space). The Breakout71 plugin uses `Box(-1, 1)` continuous actions, so this code path was never exercised before Phase 4.