### PR TITLE
fix: kill orphan port processes before starting game server

### DIFF
--- a/src/game_loader/browser_loader.py
+++ b/src/game_loader/browser_loader.py
@@ -252,7 +252,13 @@ class BrowserGameLoader(GameLoader):
                 for line in result.stdout.strip().splitlines():
                     parts = line.split()
                     if len(parts) >= 5 and "LISTENING" in line:
-                        pid = int(parts[-1])
+                        try:
+                            pid = int(parts[-1])
+                        except ValueError:
+                            continue
+                        # Don't kill our own managed process.
+                        if self._process is not None and pid == self._process.pid:
+                            continue
                         logger.info(
                             "[%s] Killing stale process PID %d on port %d",
                             self.name,


### PR DESCRIPTION
## Summary

- Adds `_kill_port_processes()` to `BrowserGameLoader` that kills stale
  processes listening on the serve port before spawning a new server
- Called in `start()` before `Popen` and in `stop()` as a safety net
  after killing the process group
- On POSIX: uses `lsof -ti :<port>` to find PIDs, kills with `SIGKILL`,
  skips own managed PID
- On Windows: uses `netstat -ano` + `taskkill /F /T /PID`
- All failures are best-effort (logged, never raised)

## Problem

Orphan `gulp` processes from previous shapez.io runs stay alive on port
3005 after `stop()` fails to kill the full `nvm→node→yarn→gulp→BrowserSync`
process tree. When the loader starts again, `_wait_until_ready()` passes
instantly (~25ms) because the orphan is still serving, but the browser
connects to a stale/broken instance (body size 1264x15), never reaches
`MainMenuState`, and `start_game()` times out.

## Testing

- 10 new tests in `TestPortCleanup` class covering POSIX kill, skip-own-PID,
  no-PIDs, lsof-not-found, process-already-dead, invalid-PID-lines,
  start-calls-kill, stop-calls-kill, Windows path
- 4 existing `TestBrowserGameLoader` tests updated to mock
  `_kill_port_processes` (prevents `subprocess.Popen` mock interference)
- 1317 passed, 15 skipped, 94.77% coverage