### PR TITLE
docs: add Phase 5 training results and cross-game comparison

### DIFF
--- a/scripts/analyze_training.py
+++ b/scripts/analyze_training.py
@@ -146,7 +146,9 @@ def compute_step_stats(steps: list[dict]) -> dict:
     rnd_raw = [s["rnd_intrinsic_raw"] for s in steps if "rnd_intrinsic_raw" in s]
     rnd_norm = [s["rnd_intrinsic_norm"] for s in steps if "rnd_intrinsic_norm" in s]
 
-    paddle_positions = [s["paddle_x"] for s in steps if "paddle_x" in s]
+    paddle_positions = [
+        s["paddle_x"] for s in steps if "paddle_x" in s and s["paddle_x"] is not None
+    ]
 
     return {
         "count": len(steps),
@@ -222,7 +224,7 @@ def analyze_paddle_movement(steps: list[dict]) -> dict:
     if not steps:
         return {"unique_positions": 0, "degenerate": False}
 
-    positions = [s["paddle_x"] for s in steps if "paddle_x" in s]
+    positions = [s["paddle_x"] for s in steps if "paddle_x" in s and s["paddle_x"] is not None]
     if not positions:
         return {"unique_positions": 0, "degenerate": False}
 


### PR DESCRIPTION
## Summary

- Complete Phase 5 (shapez.io) ROADMAP section with CNN training results (200K steps, 67 episodes, 12 unique visual states), 10-episode evaluation (trained vs random identical: mean 25.00 reward, 3000 steps, 10 critical findings each), cross-game comparison table, root cause analysis, and takeaways
- Fix `analyze_training.py` bug: filter `None` paddle_x values that crash statistics computation for games without paddle tracking (shapez.io)
- Phase 5 success criteria assessment: plugin architecture validated (zero platform changes), but exploration goal not met (survival reward is genre-limited for factory builders)

## Changes

- `documentation/ROADMAP.md` — Phase 5 section rewritten with full results
- `scripts/analyze_training.py` — Bug fix: filter `None` from paddle_x at lines 149 and 225