### PR TITLE
feat: add OCR-based score delta reward mode (--reward-mode score)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -95,6 +95,8 @@ dependencies:
       - selenium==4.40.0
       # Templating (for reporting dashboard)
       - jinja2==3.1.6
+      # OCR-based score reading (game-agnostic reward signal)
+      - pytesseract>=0.3.10
       # Documentation
       - sphinx==9.1.0
       - myst-parser==5.0.0

--- a/src/orchestrator/session_runner.py
+++ b/src/orchestrator/session_runner.py
@@ -211,6 +211,16 @@ class SessionRunner:
         the environment constructor so that ``update(frame)`` is called
         every step.  If it signals game-over, the episode terminates
         without requiring DOM/JS modal checks.
+    score_region : tuple[int, int, int, int] or None
+        Bounding box ``(x, y, w, h)`` for OCR score reading.  Only
+        used when ``reward_mode="score"``.  If None, OCR scans the
+        full frame.
+    score_ocr_interval : int
+        Run OCR every N steps to reduce overhead.  Default is 5.
+        Only used when ``reward_mode="score"``.
+    score_reward_coeff : float
+        Coefficient for score delta reward.  Default is 0.01.
+        Only used when ``reward_mode="score"``.
     """
 
     def __init__(
@@ -230,6 +240,9 @@ class SessionRunner:
         frame_stack: int = 4,
         reward_mode: str = "yolo",
         game_over_detector: Any | None = None,
+        score_region: tuple[int, int, int, int] | None = None,
+        score_ocr_interval: int = 5,
+        score_reward_coeff: float = 0.01,
     ) -> None:
         valid_policies = ("mlp", "cnn")
         if policy not in valid_policies:
@@ -249,6 +262,9 @@ class SessionRunner:
         self.frame_stack = frame_stack
         self.reward_mode = reward_mode
         self.game_over_detector = game_over_detector
+        self.score_region = score_region
+        self.score_ocr_interval = score_ocr_interval
+        self.score_reward_coeff = score_reward_coeff
 
         # Load plugin to resolve defaults
         from games import load_game_plugin
@@ -404,6 +420,9 @@ class SessionRunner:
             reward_mode=self.reward_mode,
             game_over_detector=self.game_over_detector,
             browser_instance=self._browser_instance,
+            score_region=self.score_region,
+            score_ocr_interval=self.score_ocr_interval,
+            score_reward_coeff=self.score_reward_coeff,
         )
 
         # Create frame collector

--- a/src/platform/__init__.py
+++ b/src/platform/__init__.py
@@ -11,6 +11,7 @@ from .game_over_detector import (
     ScreenFreezeStrategy,
     TextDetectionStrategy,
 )
+from .score_ocr import ScoreOCR
 
 # RNDRewardWrapper requires torch; lazy-import to avoid pulling in torch
 # unconditionally (CI/docs environments may not have it installed).
@@ -29,6 +30,7 @@ __all__ = [
     "GameOverStrategy",
     "MotionCessationStrategy",
     "RNDRewardWrapper",
+    "ScoreOCR",
     "ScreenFreezeStrategy",
     "TextDetectionStrategy",
 ]

--- a/src/platform/score_ocr.py
+++ b/src/platform/score_ocr.py
@@ -1,0 +1,167 @@
+"""OCR-based score reader for game-agnostic reward signals.
+
+Uses pytesseract (Tesseract OCR) to read numeric score values from
+game frames.  Provides throttling to avoid running OCR every frame,
+and graceful degradation when pytesseract is not installed.
+
+Parameters
+----------
+region : tuple[int, int, int, int] or None
+    ``(x, y, width, height)`` bounding box to crop before OCR.
+    If None, the entire frame is used.
+ocr_interval : int
+    Run OCR every N calls to :meth:`read_score`.  Between calls,
+    the last cached score is returned.  Default ``1`` (every frame).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class ScoreOCR:
+    """Read numeric scores from game frames via OCR.
+
+    Designed as a platform-level utility: no game-specific knowledge.
+    The caller (e.g. ``BaseGameEnv._compute_score_reward``) uses
+    score deltas as a reward signal.
+
+    Parameters
+    ----------
+    region : tuple[int, int, int, int] or None
+        ``(x, y, width, height)`` crop region.  ``None`` means full frame.
+    ocr_interval : int
+        Run OCR every *N* calls.  Cached value returned in between.
+    """
+
+    # Regex: sequences of digits, optionally separated by commas/periods
+    # (thousand separators).  Matches "1,234,567" or "1.234.567" or "12345".
+    _NUMBER_PATTERN = re.compile(r"\d[\d,.]*\d|\d")
+
+    def __init__(
+        self,
+        region: tuple[int, int, int, int] | None = None,
+        ocr_interval: int = 1,
+    ) -> None:
+        self._region = region
+        self._interval = max(ocr_interval, 1)
+        self._frame_count: int = 0
+        self._last_score: int | None = None
+
+    def read_score(self, frame: np.ndarray) -> int | None:
+        """Read the numeric score from *frame*.
+
+        Parameters
+        ----------
+        frame : np.ndarray
+            BGR or grayscale game frame.
+
+        Returns
+        -------
+        int or None
+            Detected score, or ``None`` if no number was found
+            or OCR is unavailable.
+        """
+        self._frame_count += 1
+
+        # Throttle: only run OCR on designated frames
+        if (self._frame_count - 1) % self._interval != 0:
+            return self._last_score
+
+        # Crop to region if specified
+        cropped = self._crop(frame)
+        if cropped is None:
+            return None
+
+        # Convert to grayscale if needed
+        gray = cropped.mean(axis=2).astype(np.uint8) if cropped.ndim == 3 else cropped
+
+        # Run OCR
+        text = self._run_ocr(gray)
+        if text is None:
+            return self._last_score
+
+        # Extract largest number from OCR text
+        score = self._extract_score(text)
+        self._last_score = score
+        return score
+
+    def reset(self) -> None:
+        """Clear cached state for a new episode."""
+        self._frame_count = 0
+        self._last_score = None
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _crop(self, frame: np.ndarray) -> np.ndarray | None:
+        """Crop frame to region, or return full frame if no region set.
+
+        Returns None if the region is out of bounds.
+        """
+        if self._region is None:
+            return frame
+
+        x, y, w, h = self._region
+        fh = frame.shape[0]
+        fw = frame.shape[1]
+
+        # Validate bounds
+        if x + w > fw or y + h > fh or x < 0 or y < 0:
+            logger.debug(
+                "Score region (%d,%d,%d,%d) out of bounds for frame %dx%d",
+                x,
+                y,
+                w,
+                h,
+                fw,
+                fh,
+            )
+            return None
+
+        return frame[y : y + h, x : x + w]
+
+    def _run_ocr(self, gray: np.ndarray) -> str | None:
+        """Run pytesseract OCR on a grayscale image.
+
+        Returns the raw OCR text, or None if pytesseract is not
+        available or OCR fails.
+        """
+        try:
+            import pytesseract
+        except ImportError:
+            logger.debug("pytesseract not installed; ScoreOCR disabled")
+            return None
+
+        try:
+            return pytesseract.image_to_string(gray)
+        except Exception:
+            logger.debug("OCR failed", exc_info=True)
+            return None
+
+    def _extract_score(self, text: str) -> int | None:
+        """Extract the largest integer from OCR text.
+
+        Handles thousand separators (commas and periods).
+        Returns None if no numbers are found.
+        """
+        matches = self._NUMBER_PATTERN.findall(text)
+        if not matches:
+            return None
+
+        scores: list[int] = []
+        for m in matches:
+            # Remove thousand separators (commas and periods)
+            cleaned = m.replace(",", "").replace(".", "")
+            try:
+                scores.append(int(cleaned))
+            except ValueError:
+                continue
+
+        return max(scores) if scores else None

--- a/tests/test_score_ocr.py
+++ b/tests/test_score_ocr.py
@@ -1,0 +1,304 @@
+"""Tests for the ScoreOCR platform module.
+
+Verifies score reading from game frames using OCR (pytesseract).
+All tests mock pytesseract to avoid requiring the system binary
+in CI.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import numpy as np
+
+from src.platform.score_ocr import ScoreOCR
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_frame(h: int = 480, w: int = 640, channels: int = 3) -> np.ndarray:
+    """Create a dummy BGR frame."""
+    return np.zeros((h, w, channels), dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestScoreOCRConstruction:
+    """Test ScoreOCR initialisation and parameter validation."""
+
+    def test_default_construction(self):
+        """ScoreOCR can be created with no arguments."""
+        ocr = ScoreOCR()
+        assert ocr._region is None
+        assert ocr._interval == 1
+        assert ocr._last_score is None
+
+    def test_custom_region(self):
+        """ScoreOCR accepts a (x, y, w, h) region tuple."""
+        ocr = ScoreOCR(region=(10, 20, 100, 30))
+        assert ocr._region == (10, 20, 100, 30)
+
+    def test_custom_interval(self):
+        """ScoreOCR accepts an ocr_interval parameter."""
+        ocr = ScoreOCR(ocr_interval=5)
+        assert ocr._interval == 5
+
+    def test_interval_minimum_clamped_to_1(self):
+        """ocr_interval below 1 is clamped to 1."""
+        ocr = ScoreOCR(ocr_interval=0)
+        assert ocr._interval == 1
+        ocr2 = ScoreOCR(ocr_interval=-3)
+        assert ocr2._interval == 1
+
+
+# ---------------------------------------------------------------------------
+# Score reading
+# ---------------------------------------------------------------------------
+
+
+class TestReadScore:
+    """Test read_score method."""
+
+    def test_read_score_extracts_number_from_ocr_text(self):
+        """read_score returns the detected number from OCR output."""
+        ocr = ScoreOCR()
+        frame = _make_frame()
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "Score: 1234"
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score == 1234
+
+    def test_read_score_returns_largest_number(self):
+        """When multiple numbers found, return the largest."""
+        ocr = ScoreOCR()
+        frame = _make_frame()
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "Level 3  Score 5678"
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score == 5678
+
+    def test_read_score_returns_none_when_no_numbers(self):
+        """read_score returns None when OCR finds no numbers."""
+        ocr = ScoreOCR()
+        frame = _make_frame()
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "Game Over"
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score is None
+
+    def test_read_score_returns_none_when_pytesseract_missing(self):
+        """read_score returns None gracefully when pytesseract is not installed."""
+        ocr = ScoreOCR()
+        frame = _make_frame()
+        with mock.patch.dict("sys.modules", {"pytesseract": None}):
+            score = ocr.read_score(frame)
+        assert score is None
+
+    def test_read_score_returns_none_on_ocr_exception(self):
+        """read_score returns None when OCR raises an exception."""
+        ocr = ScoreOCR()
+        frame = _make_frame()
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.side_effect = RuntimeError("OCR failed")
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score is None
+
+    def test_read_score_crops_to_region(self):
+        """read_score crops the frame to the specified region before OCR."""
+        ocr = ScoreOCR(region=(10, 20, 100, 30))
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "42"
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        # Verify the cropped region was passed to OCR
+        call_args = mock_pytesseract.image_to_string.call_args
+        cropped = call_args[0][0]
+        assert cropped.shape[0] == 30  # height
+        assert cropped.shape[1] == 100  # width
+        assert score == 42
+
+
+# ---------------------------------------------------------------------------
+# Throttling
+# ---------------------------------------------------------------------------
+
+
+class TestThrottling:
+    """Test OCR interval throttling."""
+
+    def test_throttle_skips_intermediate_frames(self):
+        """With interval=3, OCR runs on frame 1, 4, 7, etc."""
+        ocr = ScoreOCR(ocr_interval=3)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "100"
+        frame = _make_frame()
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            # Frame 1: OCR runs
+            s1 = ocr.read_score(frame)
+            assert s1 == 100
+            assert mock_pytesseract.image_to_string.call_count == 1
+
+            # Frame 2: throttled, returns cached
+            s2 = ocr.read_score(frame)
+            assert s2 == 100
+            assert mock_pytesseract.image_to_string.call_count == 1
+
+            # Frame 3: throttled, returns cached
+            s3 = ocr.read_score(frame)
+            assert s3 == 100
+            assert mock_pytesseract.image_to_string.call_count == 1
+
+            # Frame 4: OCR runs again
+            mock_pytesseract.image_to_string.return_value = "200"
+            s4 = ocr.read_score(frame)
+            assert s4 == 200
+            assert mock_pytesseract.image_to_string.call_count == 2
+
+    def test_interval_1_runs_every_frame(self):
+        """With interval=1, OCR runs every frame."""
+        ocr = ScoreOCR(ocr_interval=1)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "50"
+        frame = _make_frame()
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            ocr.read_score(frame)
+            ocr.read_score(frame)
+            ocr.read_score(frame)
+            assert mock_pytesseract.image_to_string.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Reset
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    """Test reset method."""
+
+    def test_reset_clears_state(self):
+        """reset() clears cached score and frame counter."""
+        ocr = ScoreOCR(ocr_interval=3)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "500"
+        frame = _make_frame()
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            # Read a score to populate cache
+            ocr.read_score(frame)
+            assert ocr._last_score == 500
+
+            # Reset
+            ocr.reset()
+            assert ocr._last_score is None
+            assert ocr._frame_count == 0
+
+    def test_reset_allows_immediate_ocr_on_next_read(self):
+        """After reset(), the next read_score runs OCR immediately."""
+        ocr = ScoreOCR(ocr_interval=5)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "100"
+        frame = _make_frame()
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            ocr.read_score(frame)  # frame 1: runs OCR
+            ocr.read_score(frame)  # frame 2: throttled
+            assert mock_pytesseract.image_to_string.call_count == 1
+
+            ocr.reset()
+            mock_pytesseract.image_to_string.return_value = "999"
+            s = ocr.read_score(frame)  # should run OCR immediately
+            assert s == 999
+            assert mock_pytesseract.image_to_string.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases in score parsing."""
+
+    def test_handles_zero_score(self):
+        """Score of 0 is returned correctly (not None)."""
+        ocr = ScoreOCR()
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "Score: 0"
+        frame = _make_frame()
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score == 0
+
+    def test_handles_large_numbers(self):
+        """Large numbers are handled correctly."""
+        ocr = ScoreOCR()
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "1234567890"
+        frame = _make_frame()
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score == 1234567890
+
+    def test_handles_comma_separated_numbers(self):
+        """Numbers with commas (e.g. '1,234') are parsed correctly."""
+        ocr = ScoreOCR()
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "Score: 1,234,567"
+        frame = _make_frame()
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score == 1234567
+
+    def test_handles_period_separated_numbers(self):
+        """Numbers with periods as thousand separators (e.g. '1.234') are parsed."""
+        ocr = ScoreOCR()
+        mock_pytesseract = mock.MagicMock()
+        # European-style thousand separator: "1.234.567"
+        mock_pytesseract.image_to_string.return_value = "Score: 1.234.567"
+        frame = _make_frame()
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score == 1234567
+
+    def test_grayscale_frame_handled(self):
+        """Grayscale (2D) frames are handled without error."""
+        ocr = ScoreOCR()
+        frame = np.zeros((480, 640), dtype=np.uint8)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "99"
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score == 99
+
+    def test_region_out_of_bounds_returns_none(self):
+        """If the region extends beyond frame bounds, returns None."""
+        ocr = ScoreOCR(region=(600, 400, 200, 100))
+        frame = _make_frame(480, 640)  # region extends past right edge
+        mock_pytesseract = mock.MagicMock()
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score is None
+        # OCR should not have been called
+        mock_pytesseract.image_to_string.assert_not_called()
+
+    def test_negative_numbers_ignored(self):
+        """Negative numbers in OCR text are treated as positive (score is unsigned)."""
+        ocr = ScoreOCR()
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "Score: -500"
+        frame = _make_frame()
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            score = ocr.read_score(frame)
+        assert score == 500


### PR DESCRIPTION
## Summary

- Add game-agnostic OCR-based score reading via pytesseract as a new reward mode (`--reward-mode score`), addressing the Phase 5 finding that survival reward provides no learning signal for factory-builder games where the agent cannot die
- New `ScoreOCR` class in `src/platform/score_ocr.py` extracts scores from configurable screen regions at configurable intervals, with `_compute_score_reward()` in `BaseGameEnv` providing survival reward + score delta bonus
- CLI wiring in both `train_rl.py` and `run_session.py` with `--score-region X,Y,W,H`, `--score-ocr-interval N`, `--score-reward-coeff F`

## Details

### New module: `src/platform/score_ocr.py` (167 lines)
- `ScoreOCR` class with configurable region `(x, y, w, h)` and read interval
- `read_score(frame, step)` — returns score or None (interval-gated, lazy pytesseract import)
- `_extract_score(text)` — extracts largest number from OCR text, handles comma/period thousand separators
- `reset()` for episode boundaries

### BaseGameEnv integration (`src/platform/base_env.py`)
- `"score"` added to `_VALID_REWARD_MODES`
- 3 new `__init__` params: `score_region`, `score_ocr_interval`, `score_reward_coeff`
- `_compute_score_reward()` — survival base + `delta * coeff` when OCR detects positive score change
- Score mode suppresses YOLO-based `level_cleared` (same as survival — unreliable in headless)
- OCR state reset on `reset()`, ScoreOCR lifecycle managed in `_lazy_init()`

### CLI wiring
- `train_rl.py`: `"score"` in reward-mode choices, 3 new args, `score_region` string→tuple parsing
- `run_session.py`: same 3 args, forwarded through `SessionRunner`
- `SessionRunner`: accepts and forwards `score_region`, `score_ocr_interval`, `score_reward_coeff`

### Tests: 42 new tests (21 ScoreOCR + 21 base_env)
- `test_score_ocr.py`: extraction, region validation, interval gating, reset, grayscale/color frames, lazy import
- `test_base_env.py`: 4 new classes — `TestScoreRewardMode`, `TestComputeScoreReward`, `TestScoreRewardStepIntegration`, `TestScoreRewardResetIntegration`

### Dependencies
- `pytesseract>=0.3.10` added to `environment.yml` (pip section)
- pytesseract import is lazy (inside `_run_ocr()`) — graceful degradation in CI/Docker

## Phase 6 context

This is Tier 2 of the Phase 6 Advanced Reward Strategies research from the roadmap. Survival reward works for games where survival is hard (Breakout 71, Hextris) but provides zero learning signal for games where survival is trivial (shapez.io). OCR-based score reading enables game-agnostic reward signals without requiring per-game JS bridges.