### PR TITLE
fix: add binary threshold preprocessing to ScoreOCR for improved accuracy

### DIFF
--- a/tests/test_score_ocr.py
+++ b/tests/test_score_ocr.py
@@ -408,3 +408,38 @@ class TestThresholdPreprocessing:
         processed = call_args[0][0]
         assert processed.shape == (30, 100)
         assert score == 99
+
+    def test_cv2_threshold_error_falls_back_to_raw(self):
+        """If cv2.threshold raises, fall back to raw grayscale."""
+        ocr = ScoreOCR()
+        gray = np.full((10, 10), 180, dtype=np.uint8)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "42"
+        mock_cv2 = mock.MagicMock()
+        mock_cv2.threshold.side_effect = RuntimeError("unexpected cv2 error")
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract, "cv2": mock_cv2}):
+            result = ocr._run_ocr(gray)
+
+        assert result == "42"
+        call_args = mock_pytesseract.image_to_string.call_args
+        processed = call_args[0][0]
+        assert np.all(processed == 180)
+
+    def test_non_uint8_input_normalized_before_threshold(self):
+        """Non-uint8 grayscale input is normalized to uint8 before threshold."""
+        ocr = ScoreOCR()
+        gray = np.array([[0.0, 0.5, 1.0]], dtype=np.float64)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "7"
+        mock_cv2 = self._make_mock_cv2()
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract, "cv2": mock_cv2}):
+            result = ocr._run_ocr(gray)
+
+        assert result == "7"
+        call_args = mock_pytesseract.image_to_string.call_args
+        processed = call_args[0][0]
+        assert processed.dtype == np.uint8
+        unique_vals = set(np.unique(processed))
+        assert unique_vals <= {0, 255}


### PR DESCRIPTION
## Summary

- Add `cv2.threshold()` binarisation (threshold=128) to `ScoreOCR._run_ocr()` before passing frames to pytesseract, fixing misreads from anti-aliased text (e.g., "1234" read as "1230")
- Graceful fallback to raw grayscale when cv2 is unavailable (CI Docker, minimal installs)
- 5 new tests with mock cv2 injection via `sys.modules` for CI Docker compatibility (cv2 import fails in Docker due to missing libGL.so.1)

## Details

During live validation on Hextris, pytesseract misread anti-aliased score text because raw grayscale pixels have intermediate values (e.g., 180) that confuse OCR. Binary thresholding converts all pixels to either 0 or 255, producing clean black/white text that OCR reads correctly.

The `_make_mock_cv2()` test helper creates a numpy-based threshold implementation injected via `mock.patch.dict("sys.modules")`, matching the pattern used for pytesseract mocking throughout the test suite.

## Test plan

- 5 new tests in `TestThresholdPreprocessing` class
- All 1387 existing tests pass (verified via local CI)
- `test_threshold_applied_before_ocr`: verifies output is binary {0, 255}
- `test_pixels_above_threshold_become_white`: 200 > 128 → 255
- `test_pixels_below_threshold_become_black`: 50 < 128 → 0  
- `test_cv2_unavailable_falls_back_to_raw`: cv2=None → raw grayscale passed through
- `test_threshold_preserves_frame_shape`: region crop shape preserved through threshold