### PR TITLE
docs: add Phase 7 human demo recording and Phase 8 savegame injection to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The project demonstrates what this workflow produces:
   workflow from day one
 - **Thousands of lines of documentation** generated as a natural byproduct
   of working, not a separate effort
-- **8 subsystems, 3 game plugins, full CI/CD** -- built across 61 sessions
+- **8 subsystems, 3 game plugins, full CI/CD** -- built across 62 sessions
 
 The codebase is real, the tests pass, the CI is green. The methodology
 behind it is the point.

--- a/documentation/ROADMAP.md
+++ b/documentation/ROADMAP.md
@@ -575,7 +575,7 @@ Post-process recorded demos to extract actionable knowledge (macro-actions,
 spatial priors, reward candidates, build-order curricula) that transforms
 RL training for complex games where pure pixel-based exploration fails.
 
-**Why this matters:** Phases 1-5 proved that survival reward works for
+**Why this matters:** Phases 1-6 proved that survival reward works for
 arcade/puzzle games but fails completely for factory builders (shapez.io
 trained=random). The fundamental problem is that complex games require
 multi-step action sequences that random exploration never discovers.


### PR DESCRIPTION
## Summary

- Add Phase 7 (Human Demo Recording & Knowledge Extraction) with 5 sub-phases (7a-7e): JS event recorder, human play mode, demo recorder, knowledge extraction post-processing, live validation
- Add Phase 8 (Savegame Injection) with SavegameInjector, SavegamePool, plugin hooks, CLI flags
- Add cross-cutting Game Spec Extraction task (Hextris and shapez.io missing game/env specs)
- Move Tier 3 Oracle-Guided Exploration to deprioritized section
- Update README: shapez.io status Onboarding → Complete, add shapez/ to project structure, update PR count and session count