### PR TITLE
docs: update Sphinx API pages, spec wrappers, and fix stale metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ provides strategic direction and domain expertise.
 The project demonstrates what this workflow produces:
 
 - **6-8x calendar compression** vs a traditional engineering team
-- **142+ PRs merged** with automated Copilot code review, zero review
+- **150+ PRs merged** with automated Copilot code review, zero review
   bottleneck
 - **95%+ test coverage** not from a coverage sprint, but built into the
   workflow from day one
 - **Thousands of lines of documentation** generated as a natural byproduct
   of working, not a separate effort
-- **8 subsystems, 3 game plugins, full CI/CD** -- built across 62 sessions
+- **8 subsystems, 3 game plugins, full CI/CD** -- built across 68 sessions
 
 The codebase is real, the tests pass, the CI is green. The methodology
 behind it is the point.
@@ -153,10 +153,10 @@ Platform-specific dependencies (`pywin32`, `pydirectinput`) are guarded with
 
 ```bash
 # Train a PPO agent on Breakout 71 (headless, CNN policy)
-python scripts/train_rl.py --game breakout71 --total-timesteps 200000 --headless
+python scripts/train_rl.py --game breakout71 --timesteps 200000 --headless
 
 # Train with MLP policy (requires YOLO model)
-python scripts/train_rl.py --game breakout71 --total-timesteps 200000 --headless --policy mlp
+python scripts/train_rl.py --game breakout71 --timesteps 200000 --headless --policy mlp
 ```
 
 ### Evaluation

--- a/docs/api/env.rst
+++ b/docs/api/env.rst
@@ -14,3 +14,21 @@ Breakout71Env
    :undoc-members:
    :show-inheritance:
    :no-index:
+
+HextrisEnv
+----------
+
+.. autoclass:: games.hextris.env.HextrisEnv
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
+ShapezEnv
+---------
+
+.. autoclass:: games.shapez.env.ShapezEnv
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/game_loader.rst
+++ b/docs/api/game_loader.rst
@@ -46,6 +46,24 @@ Breakout71Loader
    :show-inheritance:
    :no-index:
 
+HextrisLoader
+-------------
+
+.. autoclass:: games.hextris.loader.HextrisLoader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
+ShapezLoader
+------------
+
+.. autoclass:: games.shapez.loader.ShapezLoader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
 Factory
 -------
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ Auto-generated documentation from source code docstrings and type hints.
    oracles
    platform
    env
+   orchestrator
    perception
    reporting
    game_loader

--- a/docs/api/orchestrator.rst
+++ b/docs/api/orchestrator.rst
@@ -1,0 +1,31 @@
+Orchestrator Module
+===================
+
+Episode runner, data collection, and demo recording for QA sessions.
+
+.. automodule:: src.orchestrator
+   :no-members:
+
+SessionRunner
+-------------
+
+.. autoclass:: src.orchestrator.SessionRunner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+FrameCollector
+--------------
+
+.. autoclass:: src.orchestrator.FrameCollector
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+DemoRecorder
+------------
+
+.. autoclass:: src.orchestrator.DemoRecorder
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/platform.rst
+++ b/docs/api/platform.rst
@@ -21,3 +21,107 @@ CnnObservationWrapper
    :members:
    :undoc-members:
    :show-inheritance:
+
+CnnEvalWrapper
+--------------
+
+.. autoclass:: src.platform.CnnEvalWrapper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+EpsilonGreedyWrapper
+--------------------
+
+.. autoclass:: src.platform.EpsilonGreedyWrapper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+GameOverDetector
+----------------
+
+.. autoclass:: src.platform.GameOverDetector
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+GameOverStrategy
+----------------
+
+.. autoclass:: src.platform.GameOverStrategy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+ScreenFreezeStrategy
+--------------------
+
+.. autoclass:: src.platform.ScreenFreezeStrategy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+EntropyCollapseStrategy
+-----------------------
+
+.. autoclass:: src.platform.EntropyCollapseStrategy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+MotionCessationStrategy
+-----------------------
+
+.. autoclass:: src.platform.MotionCessationStrategy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+TextDetectionStrategy
+---------------------
+
+.. autoclass:: src.platform.TextDetectionStrategy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+RNDRewardWrapper
+----------------
+
+.. autoclass:: src.platform.RNDRewardWrapper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+ScoreOCR
+--------
+
+.. autoclass:: src.platform.ScoreOCR
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+SavegameInjector
+----------------
+
+.. autoclass:: src.platform.SavegameInjector
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+SavegamePool
+------------
+
+.. autoclass:: src.platform.SavegamePool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+EventRecorder
+-------------
+
+.. autoclass:: src.platform.event_recorder.EventRecorder
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/reporting.rst
+++ b/docs/api/reporting.rst
@@ -57,3 +57,12 @@ DashboardRenderer
    :members:
    :undoc-members:
    :show-inheritance:
+
+Finding Descriptions
+--------------------
+
+.. autofunction:: src.reporting.enrich_report_data
+
+.. autofunction:: src.reporting.get_finding_description
+
+.. autofunction:: src.reporting.get_severity_info

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "RSN Game QA"
 copyright = "2026, Roboter Schlafen Nicht"
 author = "Roboter Schlafen Nicht"
-release = "0.1.0"
+release = "0.1.0a1"
 
 # -- General configuration ----------------------------------------------------
 extensions = [
@@ -62,6 +62,9 @@ autodoc_mock_imports = [
     "pandas",
     "polars",
     "yaml",
+    "pytesseract",
+    "jinja2",
+    "weasyprint",
 ]
 
 # Napoleon settings (for Google-style docstrings)

--- a/docs/specs/hextris_env.md
+++ b/docs/specs/hextris_env.md
@@ -1,0 +1,2 @@
+```{include} ../../documentation/specs/hextris_env_spec.md
+```

--- a/docs/specs/hextris_game.md
+++ b/docs/specs/hextris_game.md
@@ -1,0 +1,2 @@
+```{include} ../../documentation/specs/hextris_game_spec.md
+```

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -8,6 +8,13 @@ Design specifications extracted from the project planning sessions.
 breakout71_game
 breakout71_behavior
 breakout71_env
+hextris_game
+hextris_env
+shapez_game
+shapez_env
+platform_architecture
+reward_strategy
+training_pipeline
 oracle_system
 capture_and_input
 reporting_system

--- a/docs/specs/platform_architecture.md
+++ b/docs/specs/platform_architecture.md
@@ -1,0 +1,2 @@
+```{include} ../../documentation/specs/platform_architecture_spec.md
+```

--- a/docs/specs/reward_strategy.md
+++ b/docs/specs/reward_strategy.md
@@ -1,0 +1,2 @@
+```{include} ../../documentation/specs/reward_strategy_spec.md
+```

--- a/docs/specs/shapez_env.md
+++ b/docs/specs/shapez_env.md
@@ -1,0 +1,2 @@
+```{include} ../../documentation/specs/shapez_env_spec.md
+```

--- a/docs/specs/shapez_game.md
+++ b/docs/specs/shapez_game.md
@@ -1,0 +1,2 @@
+```{include} ../../documentation/specs/shapez_game_spec.md
+```

--- a/docs/specs/training_pipeline.md
+++ b/docs/specs/training_pipeline.md
@@ -1,0 +1,2 @@
+```{include} ../../documentation/specs/training_pipeline_spec.md
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "rsn-game-qa"
 version = "0.1.0a1"
 description = "RL-driven autonomous game testing platform"
 requires-python = ">=3.12"
-license = "LicenseRef-Proprietary"
+license = "MIT"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/analyze_training.py
+++ b/scripts/analyze_training.py
@@ -235,7 +235,7 @@ def analyze_paddle_movement(steps: list[dict]) -> dict:
     for p in positions:
         freq[p] = freq.get(p, 0) + 1
 
-    most_common_pos = max(freq, key=freq.get)  # type: ignore[arg-type]
+    most_common_pos = max(freq, key=lambda k: freq[k])
     most_common_pct = freq[most_common_pos] / len(positions) * 100
 
     # Degenerate = one position accounts for >80% of all samples


### PR DESCRIPTION
## Summary

- Create `docs/api/orchestrator.rst` for SessionRunner, FrameCollector, DemoRecorder (new Sphinx API page)
- Expand `docs/api/platform.rst` from 2 to 15 classes (all `__all__` exports including EventRecorder, SavegameInjector, GameOverDetector, ScoreOCR, etc.)
- Add HextrisEnv, ShapezEnv to `docs/api/env.rst`
- Add HextrisLoader, ShapezLoader to `docs/api/game_loader.rst`
- Add finding_descriptions functions to `docs/api/reporting.rst`
- Create 7 spec wrapper files in `docs/specs/` for Hextris, shapez.io, platform architecture, reward strategy, and training pipeline specs
- Update `docs/specs/index.md` toctree with all 7 new entries
- Fix `docs/conf.py`: version `0.1.0a1` (was `0.1.0`), add `pytesseract`/`jinja2`/`weasyprint` to `autodoc_mock_imports`
- Fix `README.md`: PR count 150+ (was 142+), session count 68 (was 62), CLI flag `--timesteps` (was `--total-timesteps`)
- Fix `pyproject.toml`: license `MIT` (was `LicenseRef-Proprietary` but repo has MIT License file)
- Fix `scripts/analyze_training.py`: remove unnecessary `type: ignore` on line 238

## Context

Documentation debt accumulated across Phases 5-8 and Gate 4. Sphinx API pages were severely outdated (platform.rst had 2 of 15 classes, orchestrator had no page at all), spec wrappers were missing for 7 specs added in recent PRs, and several metadata fields were stale.

## Testing

- All 1602 tests pass (12 skipped), 95.19% coverage
- Lint clean (`ruff check`), format clean (`ruff format --check`)
- All 4 CI jobs pass via pre-commit hook