### PR TITLE
refactor: make detect_to_game_state() game-agnostic (dep.detect)

### DIFF
--- a/games/breakout71/env.py
+++ b/games/breakout71/env.py
@@ -266,6 +266,56 @@ class Breakout71Env(BaseGameEnv):
         """
         return "game"
 
+    def _detect_objects(self, frame: np.ndarray) -> dict[str, Any]:
+        """Convert generic YOLO detections to Breakout-specific format.
+
+        Calls the base detector's game-agnostic ``detect_to_game_state``
+        and converts the ``by_class`` dict into the Breakout-specific
+        format expected by ``build_observation``, ``compute_reward``,
+        ``check_termination``, and other game methods.
+
+        Parameters
+        ----------
+        frame : np.ndarray
+            BGR game frame.
+
+        Returns
+        -------
+        dict[str, Any]
+            Breakout-specific detection dict with keys:
+
+            - ``"paddle"`` : ``(cx, cy, w, h)`` or ``None``
+            - ``"ball"``   : ``(cx, cy, w, h)`` or ``None``
+            - ``"bricks"`` : list of ``(cx, cy, w, h)``
+            - ``"powerups"``: list of ``(cx, cy, w, h)``
+            - ``"raw_detections"`` : full detection list
+        """
+        h, w = frame.shape[:2]
+        generic = self._detector.detect_to_game_state(frame, w, h)
+        by_class = generic.get("by_class", {})
+
+        # Paddle: pick highest-confidence (first in sorted list), strip conf
+        paddle_list = by_class.get("paddle", [])
+        paddle = paddle_list[0][:4] if paddle_list else None
+
+        # Ball: pick highest-confidence, strip conf
+        ball_list = by_class.get("ball", [])
+        ball = ball_list[0][:4] if ball_list else None
+
+        # Bricks: all detections, strip conf
+        bricks = [b[:4] for b in by_class.get("brick", [])]
+
+        # Powerups: all detections, strip conf
+        powerups = [p[:4] for p in by_class.get("powerup", [])]
+
+        return {
+            "paddle": paddle,
+            "ball": ball,
+            "bricks": bricks,
+            "powerups": powerups,
+            "raw_detections": generic["raw_detections"],
+        }
+
     def build_observation(self, detections: dict[str, Any], *, reset: bool = False) -> np.ndarray:
         """Convert YOLO detections into the flat observation vector.
 

--- a/scripts/debug_pixel_loop.py
+++ b/scripts/debug_pixel_loop.py
@@ -364,8 +364,10 @@ def phase2_paddle_tracking(
         frame = cap.capture_frame()
         game_state = detector.detect_to_game_state(frame, cap.width, cap.height)
         detections = game_state["raw_detections"]
+        by_class = game_state.get("by_class", {})
 
-        paddle = game_state["paddle"]
+        paddle_list = by_class.get("paddle", [])
+        paddle = paddle_list[0][:4] if paddle_list else None
         if paddle is not None:
             detected_x = paddle[0]  # cx_norm
             error = abs(detected_x - target_x)
@@ -444,8 +446,10 @@ def phase3_ball_tracking(
         frame = cap.capture_frame()
         game_state = detector.detect_to_game_state(frame, cap.width, cap.height)
         frame_count += 1
+        by_class = game_state.get("by_class", {})
 
-        ball = game_state["ball"]
+        ball_list = by_class.get("ball", [])
+        ball = ball_list[0][:4] if ball_list else None
         if ball is not None:
             ball_count += 1
             elapsed = time.perf_counter() - start
@@ -616,9 +620,12 @@ def phase4_gameplay_loop(
         if dt > 0:
             fps_samples.append(1.0 / dt)
 
-        ball = game_state["ball"]
-        paddle = game_state["paddle"]
-        bricks = game_state["bricks"]
+        by_class = game_state.get("by_class", {})
+        ball_list = by_class.get("ball", [])
+        ball = ball_list[0][:4] if ball_list else None
+        paddle_list = by_class.get("paddle", [])
+        paddle = paddle_list[0][:4] if paddle_list else None
+        bricks = [b[:4] for b in by_class.get("brick", [])]
         brick_counts.append(len(bricks))
 
         if ball is not None:

--- a/src/perception/breakout_capture.py
+++ b/src/perception/breakout_capture.py
@@ -3,6 +3,12 @@
 Convenience functions that bridge the :mod:`src.capture` and
 :mod:`src.perception` subsystems, providing a simple two-step pipeline:
 grab a frame from the game window, then run YOLO detection on it.
+
+.. deprecated:: 0.2
+    The ``detect_objects`` function returns the generic
+    ``detect_to_game_state`` format (``by_class`` / ``raw_detections``).
+    Breakout-specific grouping now lives in
+    ``Breakout71Env._detect_objects()``.
 """
 
 from __future__ import annotations
@@ -46,7 +52,7 @@ def detect_objects(
     frame_width: int | None = None,
     frame_height: int | None = None,
 ) -> dict[str, Any]:
-    """Run YOLO detection on a game frame and return the game state.
+    """Run YOLO detection on a game frame and return detection results.
 
     Parameters
     ----------
@@ -62,14 +68,13 @@ def detect_objects(
     Returns
     -------
     dict[str, Any]
-        Game-state dict as returned by
+        Generic detection dict as returned by
         :meth:`YoloDetector.detect_to_game_state`:
 
-        - ``"paddle"`` : normalised bbox tuple or None
-        - ``"ball"``   : normalised bbox tuple or None
-        - ``"bricks"`` : list of normalised bbox tuples
-        - ``"powerups"``: list of normalised bbox tuples
-        - ``"raw_detections"``: full detection list
+        - ``"by_class"`` : dict mapping class names to lists of
+          ``(cx, cy, w, h, confidence)`` tuples sorted by confidence
+          descending.
+        - ``"raw_detections"`` : full detection list.
 
     Raises
     ------

--- a/src/perception/yolo_detector.py
+++ b/src/perception/yolo_detector.py
@@ -408,11 +408,16 @@ class YoloDetector:
         frame_width: int,
         frame_height: int,
     ) -> dict[str, Any]:
-        """Run detection and convert results to game-state dict.
+        """Run detection and group results by class name.
 
-        This is the primary interface used by ``Breakout71Env``.  It
-        runs ``detect()`` and groups results by class, extracting the
-        paddle position, ball position, and brick grid.
+        Game-agnostic interface: runs ``detect()`` and groups results
+        into normalised bounding boxes keyed by class name.  Each
+        class maps to a list of ``(cx, cy, w, h, confidence)`` tuples
+        sorted by confidence descending.
+
+        Game-specific interpretation (e.g. picking the highest-confidence
+        paddle) is the responsibility of each game plugin's
+        ``_detect_objects()`` override.
 
         Parameters
         ----------
@@ -426,56 +431,40 @@ class YoloDetector:
         Returns
         -------
         dict[str, Any]
-            Game state with keys:
+            Detection results with keys:
 
-            - ``"paddle"`` : ``(cx_norm, cy_norm, w_norm, h_norm)`` or None
-            - ``"ball"``   : ``(cx_norm, cy_norm, w_norm, h_norm)`` or None
-            - ``"bricks"`` : list of ``(cx_norm, cy_norm, w_norm, h_norm)``
-            - ``"powerups"``: list of ``(cx_norm, cy_norm, w_norm, h_norm)``
-            - ``"raw_detections"``: full detection list
+            - ``"by_class"`` : ``dict[str, list[tuple]]`` — each class
+              name maps to a list of
+              ``(cx_norm, cy_norm, w_norm, h_norm, confidence)`` tuples,
+              sorted by confidence descending.
+            - ``"raw_detections"`` : full detection list from ``detect()``.
         """
         raw = self.detect(frame)
 
-        paddle: tuple[float, float, float, float] | None = None
-        ball: tuple[float, float, float, float] | None = None
-        bricks: list[tuple[float, float, float, float]] = []
-        powerups: list[tuple[float, float, float, float]] = []
+        by_class: dict[str, list[tuple[float, float, float, float, float]]] = {}
 
-        # Track best confidence for paddle/ball (pick highest if multiple)
-        best_paddle_conf = -1.0
-        best_ball_conf = -1.0
+        fw = frame_width if frame_width > 0 else 1
+        fh = frame_height if frame_height > 0 else 1
 
         for det in raw:
             name = det["class_name"]
             conf = det["confidence"]
-            xyxy = det["bbox_xyxy"]
-            x1, y1, x2, y2 = xyxy
+            x1, y1, x2, y2 = det["bbox_xyxy"]
 
-            # Normalise using provided frame dimensions
-            fw = frame_width if frame_width > 0 else 1
-            fh = frame_height if frame_height > 0 else 1
             cx_norm = ((x1 + x2) / 2.0) / fw
             cy_norm = ((y1 + y2) / 2.0) / fh
             w_norm = (x2 - x1) / fw
             h_norm = (y2 - y1) / fh
-            bbox_norm = (cx_norm, cy_norm, w_norm, h_norm)
 
-            if name == "paddle" and conf > best_paddle_conf:
-                paddle = bbox_norm
-                best_paddle_conf = conf
-            elif name == "ball" and conf > best_ball_conf:
-                ball = bbox_norm
-                best_ball_conf = conf
-            elif name == "brick":
-                bricks.append(bbox_norm)
-            elif name == "powerup":
-                powerups.append(bbox_norm)
+            entry = (cx_norm, cy_norm, w_norm, h_norm, conf)
+            by_class.setdefault(name, []).append(entry)
+
+        # Sort each class list by confidence descending
+        for entries in by_class.values():
+            entries.sort(key=lambda t: t[4], reverse=True)
 
         return {
-            "paddle": paddle,
-            "ball": ball,
-            "bricks": bricks,
-            "powerups": powerups,
+            "by_class": by_class,
             "raw_detections": raw,
         }
 

--- a/src/platform/base_env.py
+++ b/src/platform/base_env.py
@@ -1233,7 +1233,16 @@ class BaseGameEnv(gym.Env, abc.ABC):
         return frame
 
     def _detect_objects(self, frame: np.ndarray) -> dict[str, Any]:
-        """Run YOLO inference on a frame.
+        """Run YOLO inference on a frame and return game-specific detections.
+
+        The default implementation calls
+        ``YoloDetector.detect_to_game_state`` which returns a generic
+        dict with ``"by_class"`` and ``"raw_detections"`` keys.
+
+        Game plugins that use YOLO should override this method to
+        convert the generic format into game-specific keys.  Games
+        that don't use YOLO (e.g. Hextris, shapez.io) override this
+        to return ``{}``.
 
         Parameters
         ----------
@@ -1243,7 +1252,7 @@ class BaseGameEnv(gym.Env, abc.ABC):
         Returns
         -------
         dict[str, Any]
-            Detection results from ``YoloDetector.detect_to_game_state``.
+            Detection results.  Format depends on the game plugin.
         """
         h, w = frame.shape[:2]
         return self._detector.detect_to_game_state(frame, w, h)

--- a/tests/test_base_env.py
+++ b/tests/test_base_env.py
@@ -96,6 +96,18 @@ class StubEnv(BaseGameEnv):
         self._no_ball_count = 0
         self._no_bricks_count = 0
 
+    def _detect_objects(self, frame: np.ndarray) -> dict[str, Any]:
+        """Convert generic YOLO detections to StubEnv format."""
+        h, w = frame.shape[:2]
+        generic = self._detector.detect_to_game_state(frame, w, h)
+        by_class = generic.get("by_class", {})
+        ball_list = by_class.get("ball", [])
+        ball = ball_list[0][:4] if ball_list else None
+        return {
+            "ball": ball,
+            "raw_detections": generic.get("raw_detections", []),
+        }
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -103,12 +115,42 @@ class StubEnv(BaseGameEnv):
 
 
 def _make_detections(*, ball=(0.5, 0.5, 0.02, 0.02), bricks=None):
-    """Build a minimal detections dict."""
+    """Build a minimal detections dict.
+
+    Used for direct calls to build_observation(), compute_reward(), etc.
+    For mocking detect_to_game_state, use _generic_make_detections() instead.
+    """
     return {
         "ball": ball,
         "paddle": (0.5, 0.9, 0.1, 0.02),
         "bricks": bricks or [(0.1 * i, 0.1, 0.05, 0.03) for i in range(5)],
         "powerups": [],
+        "raw_detections": [],
+    }
+
+
+def _generic_make_detections(
+    *,
+    ball=(0.5, 0.5, 0.02, 0.02),
+    bricks=None,
+    ball_conf=0.90,
+    brick_conf=0.80,
+):
+    """Build a generic detections dict matching YoloDetector.detect_to_game_state.
+
+    Returns the game-agnostic by_class format that _detect_objects()
+    converts into game-specific keys.
+    """
+    if bricks is None:
+        bricks = [(0.1 * i, 0.1, 0.05, 0.03) for i in range(5)]
+    by_class: dict[str, list] = {}
+    by_class["paddle"] = [(0.5, 0.9, 0.1, 0.02, 0.95)]
+    if ball is not None:
+        by_class["ball"] = [(*ball, ball_conf)]
+    if bricks:
+        by_class["brick"] = [(*b, brick_conf) for b in bricks]
+    return {
+        "by_class": by_class,
         "raw_detections": [],
     }
 
@@ -126,7 +168,7 @@ def _make_ready_env(**kwargs):
 
     frame = np.zeros((480, 640, 3), dtype=np.uint8)
     env._capture.capture_frame.return_value = frame
-    env._detector.detect_to_game_state.return_value = _make_detections()
+    env._detector.detect_to_game_state.return_value = _generic_make_detections()
     env._last_frame = frame
     return env
 
@@ -417,7 +459,7 @@ class TestReset:
         """reset() raises RuntimeError if on_reset_detections always False."""
         env = _make_ready_env()
         # Return no ball in detections
-        env._detector.detect_to_game_state.return_value = _make_detections(ball=None)
+        env._detector.detect_to_game_state.return_value = _generic_make_detections(ball=None)
 
         with pytest.raises(RuntimeError, match="failed to get valid detections"):
             env.reset()
@@ -941,7 +983,7 @@ class TestSurvivalReward:
         """Late game-over (ball disappears) in survival mode uses survival terminal."""
         env = _make_ready_env(reward_mode="survival")
         # Make detection return no ball
-        no_ball_det = _make_detections(ball=None)
+        no_ball_det = _generic_make_detections(ball=None)
         env._detector.detect_to_game_state.return_value = no_ball_det
         # Make handle_modals return game_over when called with dismiss=False
         env.handle_modals = lambda **kw: (
@@ -1010,7 +1052,7 @@ class TestSurvivalResetDetections:
         """
         env = _make_ready_env(reward_mode="survival")
         # Simulate YOLO failing to detect ball (common in headless mode)
-        env._detector.detect_to_game_state.return_value = _make_detections(ball=None)
+        env._detector.detect_to_game_state.return_value = _generic_make_detections(ball=None)
 
         # Should NOT raise — survival mode is lenient
         obs, info = env.reset()
@@ -1020,7 +1062,7 @@ class TestSurvivalResetDetections:
     def test_reset_still_validates_in_yolo_mode(self, mock_time):
         """reset() still requires valid detections in yolo mode."""
         env = _make_ready_env(reward_mode="yolo")
-        env._detector.detect_to_game_state.return_value = _make_detections(ball=None)
+        env._detector.detect_to_game_state.return_value = _generic_make_detections(ball=None)
 
         with pytest.raises(RuntimeError, match="failed to get valid detections"):
             env.reset()
@@ -1035,8 +1077,8 @@ class TestSurvivalResetDetections:
         env = _make_ready_env(reward_mode="survival")
         # First call: no ball; second call: ball detected
         env._detector.detect_to_game_state.side_effect = [
-            _make_detections(ball=None),
-            _make_detections(ball=(0.5, 0.5, 0.02, 0.02)),
+            _generic_make_detections(ball=None),
+            _generic_make_detections(ball=(0.5, 0.5, 0.02, 0.02)),
         ]
 
         obs, info = env.reset()
@@ -1323,7 +1365,7 @@ class TestScoreRewardResetIntegration:
         OCR-based reward computation.
         """
         env = _make_ready_env(reward_mode="score")
-        env._detector.detect_to_game_state.return_value = _make_detections(ball=None)
+        env._detector.detect_to_game_state.return_value = _generic_make_detections(ball=None)
 
         # Should NOT raise — score mode is lenient
         obs, info = env.reset()
@@ -1577,7 +1619,7 @@ class TestSavegameInjectorResetIntegration:
         env._detector = mock.MagicMock()
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         env._capture.capture_frame.return_value = frame
-        env._detector.detect_to_game_state.return_value = _make_detections()
+        env._detector.detect_to_game_state.return_value = _generic_make_detections()
         env._last_frame = frame
         env._driver = mock.MagicMock()
 

--- a/tests/test_browser_crash_recovery.py
+++ b/tests/test_browser_crash_recovery.py
@@ -100,6 +100,18 @@ class StubEnv(BaseGameEnv):
         self._no_ball_count = 0
         self._no_bricks_count = 0
 
+    def _detect_objects(self, frame: np.ndarray) -> dict[str, Any]:
+        """Convert generic YOLO detections to StubEnv format."""
+        h, w = frame.shape[:2]
+        generic = self._detector.detect_to_game_state(frame, w, h)
+        by_class = generic.get("by_class", {})
+        ball_list = by_class.get("ball", [])
+        ball = ball_list[0][:4] if ball_list else None
+        return {
+            "ball": ball,
+            "raw_detections": generic.get("raw_detections", []),
+        }
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -107,12 +119,38 @@ class StubEnv(BaseGameEnv):
 
 
 def _make_detections(*, ball=(0.5, 0.5, 0.02, 0.02), bricks=None):
-    """Build a minimal detections dict."""
+    """Build a minimal detections dict.
+
+    Used for direct calls to build_observation(), compute_reward(), etc.
+    For mocking detect_to_game_state, use _generic_make_detections() instead.
+    """
     return {
         "ball": ball,
         "paddle": (0.5, 0.9, 0.1, 0.02),
         "bricks": bricks or [(0.1 * i, 0.1, 0.05, 0.03) for i in range(5)],
         "powerups": [],
+        "raw_detections": [],
+    }
+
+
+def _generic_make_detections(
+    *,
+    ball=(0.5, 0.5, 0.02, 0.02),
+    bricks=None,
+    ball_conf=0.90,
+    brick_conf=0.80,
+):
+    """Build a generic detections dict matching YoloDetector.detect_to_game_state."""
+    if bricks is None:
+        bricks = [(0.1 * i, 0.1, 0.05, 0.03) for i in range(5)]
+    by_class: dict[str, list] = {}
+    by_class["paddle"] = [(0.5, 0.9, 0.1, 0.02, 0.95)]
+    if ball is not None:
+        by_class["ball"] = [(*ball, ball_conf)]
+    if bricks:
+        by_class["brick"] = [(*b, brick_conf) for b in bricks]
+    return {
+        "by_class": by_class,
         "raw_detections": [],
     }
 
@@ -130,7 +168,7 @@ def _make_ready_env(**kwargs):
 
     frame = np.zeros((480, 640, 3), dtype=np.uint8)
     env._capture.capture_frame.return_value = frame
-    env._detector.detect_to_game_state.return_value = _make_detections()
+    env._detector.detect_to_game_state.return_value = _generic_make_detections()
     env._last_frame = frame
     return env
 

--- a/tests/test_cnn_wrapper.py
+++ b/tests/test_cnn_wrapper.py
@@ -106,7 +106,11 @@ def _detections(
     bricks=None,
     powerups=None,
 ):
-    """Build a fake detections dict."""
+    """Build a fake Breakout-specific detections dict.
+
+    Used for direct calls to build_observation(), compute_reward(), etc.
+    For mocking detect_to_game_state, use _generic_detections() instead.
+    """
     if bricks is None:
         bricks = [(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)]
     return {
@@ -114,6 +118,35 @@ def _detections(
         "ball": ball,
         "bricks": bricks,
         "powerups": powerups or [],
+        "raw_detections": [],
+    }
+
+
+def _generic_detections(
+    paddle=(0.5, 0.9, 0.1, 0.02),
+    ball=(0.5, 0.5, 0.02, 0.02),
+    bricks=None,
+    powerups=None,
+    *,
+    paddle_conf=0.95,
+    ball_conf=0.90,
+    brick_conf=0.80,
+    powerup_conf=0.60,
+):
+    """Build a generic detections dict matching YoloDetector.detect_to_game_state."""
+    if bricks is None:
+        bricks = [(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)]
+    by_class: dict[str, list] = {}
+    if paddle is not None:
+        by_class["paddle"] = [(*paddle, paddle_conf)]
+    if ball is not None:
+        by_class["ball"] = [(*ball, ball_conf)]
+    if bricks:
+        by_class["brick"] = [(*b, brick_conf) for b in bricks]
+    if powerups:
+        by_class["powerup"] = [(*p, powerup_conf) for p in powerups]
+    return {
+        "by_class": by_class,
         "raw_detections": [],
     }
 
@@ -147,7 +180,7 @@ def _make_base_env_ready(bricks_count=10):
     env._capture.capture_frame.return_value = _frame()
 
     env._detector = mock.MagicMock()
-    env._detector.detect_to_game_state.return_value = _detections(
+    env._detector.detect_to_game_state.return_value = _generic_detections(
         bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(bricks_count)]
     )
     return env
@@ -340,7 +373,7 @@ class TestCnnWrapperStep:
         base_env = _make_base_env_ready()
         # Simulate ball missing for several frames to trigger game-over
         base_env._no_ball_count = 5
-        base_env._detector.detect_to_game_state.return_value = _detections(
+        base_env._detector.detect_to_game_state.return_value = _generic_detections(
             ball=None, bricks=[(0.1, 0.1, 0.05, 0.03)] * 10
         )
         base_env._driver.execute_script.return_value = {

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -61,7 +61,11 @@ def _detections(
     bricks=None,
     powerups=None,
 ):
-    """Build a fake detections dict matching YoloDetector.detect_to_game_state."""
+    """Build a fake Breakout-specific detections dict.
+
+    Used for direct calls to build_observation(), compute_reward(), etc.
+    For mocking detect_to_game_state, use _generic_detections() instead.
+    """
     if bricks is None:
         bricks = [(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)]
     return {
@@ -69,6 +73,39 @@ def _detections(
         "ball": ball,
         "bricks": bricks,
         "powerups": powerups or [],
+        "raw_detections": [],
+    }
+
+
+def _generic_detections(
+    paddle=(0.5, 0.9, 0.1, 0.02),
+    ball=(0.5, 0.5, 0.02, 0.02),
+    bricks=None,
+    powerups=None,
+    *,
+    paddle_conf=0.95,
+    ball_conf=0.90,
+    brick_conf=0.80,
+    powerup_conf=0.60,
+):
+    """Build a generic detections dict matching YoloDetector.detect_to_game_state.
+
+    Returns the game-agnostic by_class format that Breakout71Env._detect_objects()
+    converts into Breakout-specific keys.
+    """
+    if bricks is None:
+        bricks = [(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)]
+    by_class: dict[str, list] = {}
+    if paddle is not None:
+        by_class["paddle"] = [(*paddle, paddle_conf)]
+    if ball is not None:
+        by_class["ball"] = [(*ball, ball_conf)]
+    if bricks:
+        by_class["brick"] = [(*b, brick_conf) for b in bricks]
+    if powerups:
+        by_class["powerup"] = [(*p, powerup_conf) for p in powerups]
+    return {
+        "by_class": by_class,
         "raw_detections": [],
     }
 
@@ -128,7 +165,7 @@ def _make_env_ready(bricks_count=10):
     env._game_canvas = mock.MagicMock()
     env._canvas_size = (640, 480)
     env._detector = mock.MagicMock()
-    env._detector.detect_to_game_state.return_value = _detections(
+    env._detector.detect_to_game_state.return_value = _generic_detections(
         bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(bricks_count)]
     )
     return env
@@ -417,21 +454,21 @@ class TestDetectObjects:
         """_detect_objects should delegate to YoloDetector.detect_to_game_state."""
         env = Breakout71Env()
         frame = _frame(480, 640)
-        expected_detections = _detections()
         env._detector = mock.MagicMock()
-        env._detector.detect_to_game_state.return_value = expected_detections
+        env._detector.detect_to_game_state.return_value = _generic_detections()
 
         result = env._detect_objects(frame)
 
         env._detector.detect_to_game_state.assert_called_once_with(frame, 640, 480)
-        assert result == expected_detections
+        # _detect_objects converts generic by_class → Breakout-specific keys
+        assert result == _detections()
 
     def test_detect_objects_passes_correct_dimensions(self):
         """_detect_objects should pass frame width and height correctly."""
         env = Breakout71Env()
         frame = _frame(100, 200)
         env._detector = mock.MagicMock()
-        env._detector.detect_to_game_state.return_value = _detections()
+        env._detector.detect_to_game_state.return_value = _generic_detections()
 
         env._detect_objects(frame)
 
@@ -1133,7 +1170,7 @@ class TestReset:
         env._game_canvas = mock.MagicMock()
         env._canvas_size = (640, 480)
         env._detector = mock.MagicMock()
-        env._detector.detect_to_game_state.return_value = _detections()
+        env._detector.detect_to_game_state.return_value = _generic_detections()
         return env
 
     @mock.patch("games.breakout71.env.time")
@@ -1194,7 +1231,7 @@ class TestReset:
         # After lazy_init, we need the sub-components set up
         _setup_capture_mock(env)
         env._detector = mock.MagicMock()
-        env._detector.detect_to_game_state.return_value = _detections()
+        env._detector.detect_to_game_state.return_value = _generic_detections()
         env._game_canvas = mock.MagicMock()
         env._canvas_size = (640, 480)
 
@@ -1212,7 +1249,7 @@ class TestReset:
         env._game_canvas = mock.MagicMock()
         env._canvas_size = (640, 480)
         env._detector = mock.MagicMock()
-        env._detector.detect_to_game_state.return_value = _detections(ball=None)
+        env._detector.detect_to_game_state.return_value = _generic_detections(ball=None)
 
         with pytest.raises(RuntimeError, match="failed to get valid detections"):
             env.reset()
@@ -1291,7 +1328,7 @@ class TestStep:
         env._no_ball_count = Breakout71Env._BALL_LOST_THRESHOLD - 1
 
         # Return detections with no ball
-        env._detector.detect_to_game_state.return_value = _detections(
+        env._detector.detect_to_game_state.return_value = _generic_detections(
             ball=None,
             bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)],
         )
@@ -1321,7 +1358,7 @@ class TestStep:
         env._no_bricks_count = Breakout71Env._LEVEL_CLEAR_THRESHOLD - 1
 
         # Return detections with no bricks
-        env._detector.detect_to_game_state.return_value = _detections(bricks=[])
+        env._detector.detect_to_game_state.return_value = _generic_detections(bricks=[])
 
         _, _, terminated, _, _ = env.step(_action())
 
@@ -1909,7 +1946,7 @@ class TestModalCheckThrottling:
         assert env._no_ball_count == 0  # ball was visible last step
 
         # YOLO detects no ball (modal occludes it) but sees bricks
-        env._detector.detect_to_game_state.return_value = _detections(
+        env._detector.detect_to_game_state.return_value = _generic_detections(
             ball=None, bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(5)]
         )
 
@@ -1932,7 +1969,7 @@ class TestModalCheckThrottling:
 
         # Set up YOLO to return fewer bricks (simulating modal occlusion
         # that would normally produce a large positive brick-delta reward)
-        env._detector.detect_to_game_state.return_value = _detections(
+        env._detector.detect_to_game_state.return_value = _generic_detections(
             ball=None, bricks=[(0.5, 0.1, 0.05, 0.03)]
         )
 
@@ -2121,7 +2158,7 @@ class TestStepMultiLevel:
 
         # Simulate zero bricks for 3+ frames → level_cleared
         env._no_bricks_count = 2  # one more zero will trigger
-        env._detector.detect_to_game_state.return_value = _detections(bricks=[])
+        env._detector.detect_to_game_state.return_value = _generic_detections(bricks=[])
 
         with mock.patch.object(env, "_handle_level_transition", return_value=True):
             _, reward, terminated, truncated, info = env.step(_action())
@@ -2135,7 +2172,7 @@ class TestStepMultiLevel:
 
         # Simulate level_cleared
         env._no_bricks_count = 2
-        env._detector.detect_to_game_state.return_value = _detections(bricks=[])
+        env._detector.detect_to_game_state.return_value = _generic_detections(bricks=[])
 
         with mock.patch.object(env, "_handle_level_transition", return_value=False):
             _, reward, terminated, truncated, info = env.step(_action())
@@ -2147,7 +2184,7 @@ class TestStepMultiLevel:
         env = self._make_env_ready(bricks_count=10)
 
         env._no_bricks_count = 2
-        env._detector.detect_to_game_state.return_value = _detections(bricks=[])
+        env._detector.detect_to_game_state.return_value = _generic_detections(bricks=[])
 
         with mock.patch.object(env, "_handle_level_transition", return_value=True):
             _, reward, terminated, _, _ = env.step(_action())
@@ -2161,7 +2198,7 @@ class TestStepMultiLevel:
 
         # Ball lost for enough frames
         env._no_ball_count = env._BALL_LOST_THRESHOLD
-        env._detector.detect_to_game_state.return_value = _detections(
+        env._detector.detect_to_game_state.return_value = _generic_detections(
             ball=None,
             bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)],
         )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -616,17 +616,18 @@ class TestEnvBugFixes:
 
         # First 2 detections: no ball. Third: ball found.
         no_ball = {
-            "paddle": (0.5, 0.9, 0.1, 0.02),
-            "ball": None,
-            "bricks": [(0.1, 0.1, 0.05, 0.03)] * 10,
-            "powerups": [],
+            "by_class": {
+                "paddle": [(0.5, 0.9, 0.1, 0.02, 0.95)],
+                "brick": [(0.1, 0.1, 0.05, 0.03, 0.80)] * 10,
+            },
             "raw_detections": [],
         }
         with_ball = {
-            "paddle": (0.5, 0.9, 0.1, 0.02),
-            "ball": (0.5, 0.5, 0.02, 0.02),
-            "bricks": [(0.1, 0.1, 0.05, 0.03)] * 10,
-            "powerups": [],
+            "by_class": {
+                "paddle": [(0.5, 0.9, 0.1, 0.02, 0.95)],
+                "ball": [(0.5, 0.5, 0.02, 0.02, 0.90)],
+                "brick": [(0.1, 0.1, 0.05, 0.03, 0.80)] * 10,
+            },
             "raw_detections": [],
         }
         mock_detector.detect_to_game_state.side_effect = [no_ball, no_ball, with_ball]
@@ -655,10 +656,11 @@ class TestEnvBugFixes:
 
         # Retry detection returns 10 bricks
         retry_dets = {
-            "paddle": (0.5, 0.9, 0.1, 0.02),
-            "ball": (0.5, 0.5, 0.02, 0.02),
-            "bricks": [(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)],
-            "powerups": [],
+            "by_class": {
+                "paddle": [(0.5, 0.9, 0.1, 0.02, 0.95)],
+                "ball": [(0.5, 0.5, 0.02, 0.02, 0.90)],
+                "brick": [(0.1 * i, 0.1, 0.05, 0.03, 0.80) for i in range(10)],
+            },
             "raw_detections": [],
         }
         mock_detector.detect_to_game_state.return_value = retry_dets

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -425,10 +425,13 @@ class TestYoloDetectorDetect:
 
 
 class TestYoloDetectorGameState:
-    """Tests for detect_to_game_state — structured game state extraction."""
+    """Tests for detect_to_game_state — generic game state extraction.
+
+    These tests verify the generic by_class grouping API.
+    """
 
     def test_full_game_state(self):
-        """detect_to_game_state returns paddle, ball, bricks, powerups."""
+        """detect_to_game_state returns by_class with all detected classes."""
         detector = _make_detector_with_mock_model(
             boxes_data=[
                 (0, 0.95, (280, 440, 360, 460)),  # paddle
@@ -441,14 +444,14 @@ class TestYoloDetectorGameState:
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         state = detector.detect_to_game_state(frame, 640, 480)
 
-        assert state["paddle"] is not None
-        assert state["ball"] is not None
-        assert len(state["bricks"]) == 2
-        assert len(state["powerups"]) == 1
+        assert len(state["by_class"]["paddle"]) == 1
+        assert len(state["by_class"]["ball"]) == 1
+        assert len(state["by_class"]["brick"]) == 2
+        assert len(state["by_class"]["powerup"]) == 1
         assert len(state["raw_detections"]) == 5
 
-    def test_missing_paddle_returns_none(self):
-        """detect_to_game_state returns None for paddle when not detected."""
+    def test_missing_paddle_not_in_by_class(self):
+        """detect_to_game_state omits 'paddle' from by_class when not detected."""
         detector = _make_detector_with_mock_model(
             boxes_data=[
                 (1, 0.90, (310, 200, 330, 220)),  # ball only
@@ -457,11 +460,11 @@ class TestYoloDetectorGameState:
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         state = detector.detect_to_game_state(frame, 640, 480)
 
-        assert state["paddle"] is None
-        assert state["ball"] is not None
+        assert "paddle" not in state["by_class"]
+        assert "ball" in state["by_class"]
 
-    def test_missing_ball_returns_none(self):
-        """detect_to_game_state returns None for ball when not detected."""
+    def test_missing_ball_not_in_by_class(self):
+        """detect_to_game_state omits 'ball' from by_class when not detected."""
         detector = _make_detector_with_mock_model(
             boxes_data=[
                 (0, 0.95, (280, 440, 360, 460)),  # paddle only
@@ -470,23 +473,20 @@ class TestYoloDetectorGameState:
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         state = detector.detect_to_game_state(frame, 640, 480)
 
-        assert state["paddle"] is not None
-        assert state["ball"] is None
+        assert "paddle" in state["by_class"]
+        assert "ball" not in state["by_class"]
 
     def test_no_detections_returns_empty_state(self):
-        """detect_to_game_state returns all-empty when nothing detected."""
+        """detect_to_game_state returns empty by_class when nothing detected."""
         detector = _make_detector_with_mock_model(boxes_data=[])
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         state = detector.detect_to_game_state(frame, 640, 480)
 
-        assert state["paddle"] is None
-        assert state["ball"] is None
-        assert state["bricks"] == []
-        assert state["powerups"] == []
+        assert state["by_class"] == {}
         assert state["raw_detections"] == []
 
-    def test_multiple_paddles_picks_highest_confidence(self):
-        """When multiple paddles detected, pick the one with highest confidence."""
+    def test_multiple_paddles_all_in_list(self):
+        """When multiple paddles detected, all appear sorted by confidence."""
         detector = _make_detector_with_mock_model(
             boxes_data=[
                 (0, 0.60, (100, 440, 180, 460)),  # paddle low conf
@@ -496,14 +496,14 @@ class TestYoloDetectorGameState:
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         state = detector.detect_to_game_state(frame, 640, 480)
 
-        # Should pick the second paddle (higher confidence)
-        assert state["paddle"] is not None
-        cx = state["paddle"][0]
-        expected_cx = (280 + 360) / 2.0 / 640
-        assert cx == pytest.approx(expected_cx, abs=0.001)
+        paddles = state["by_class"]["paddle"]
+        assert len(paddles) == 2
+        # Sorted by confidence descending
+        assert paddles[0][4] == pytest.approx(0.95)
+        assert paddles[1][4] == pytest.approx(0.60)
 
-    def test_multiple_balls_picks_highest_confidence(self):
-        """When multiple balls detected, pick the one with highest confidence."""
+    def test_multiple_balls_all_in_list(self):
+        """When multiple balls detected, all appear sorted by confidence."""
         detector = _make_detector_with_mock_model(
             boxes_data=[
                 (1, 0.50, (50, 50, 70, 70)),  # ball low conf
@@ -513,10 +513,10 @@ class TestYoloDetectorGameState:
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         state = detector.detect_to_game_state(frame, 640, 480)
 
-        assert state["ball"] is not None
-        cx = state["ball"][0]
-        expected_cx = (310 + 330) / 2.0 / 640
-        assert cx == pytest.approx(expected_cx, abs=0.001)
+        balls = state["by_class"]["ball"]
+        assert len(balls) == 2
+        assert balls[0][4] == pytest.approx(0.99)
+        assert balls[1][4] == pytest.approx(0.50)
 
     def test_normalisation_uses_provided_dimensions(self):
         """detect_to_game_state uses frame_width/frame_height, not frame.shape."""
@@ -529,16 +529,17 @@ class TestYoloDetectorGameState:
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         state = detector.detect_to_game_state(frame, 1000, 500)
 
-        assert state["paddle"] is not None
-        cx, cy, w, h = state["paddle"]
+        paddles = state["by_class"]["paddle"]
+        assert len(paddles) == 1
+        cx, cy, w, h, _conf = paddles[0]
         # cx = (0+100)/2/1000 = 0.05, cy = (0+50)/2/500 = 0.05
         assert cx == pytest.approx(0.05, abs=0.001)
         assert cy == pytest.approx(0.05, abs=0.001)
         assert w == pytest.approx(100 / 1000, abs=0.001)
         assert h == pytest.approx(50 / 500, abs=0.001)
 
-    def test_wall_detections_not_in_game_state_keys(self):
-        """Wall detections appear only in raw_detections, not in named keys."""
+    def test_wall_detections_in_by_class(self):
+        """Wall detections appear in by_class under 'wall' key."""
         detector = _make_detector_with_mock_model(
             boxes_data=[
                 (4, 0.80, (0, 0, 640, 10)),  # wall
@@ -547,12 +548,142 @@ class TestYoloDetectorGameState:
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         state = detector.detect_to_game_state(frame, 640, 480)
 
-        assert state["paddle"] is None
-        assert state["ball"] is None
-        assert state["bricks"] == []
-        assert state["powerups"] == []
+        assert "wall" in state["by_class"]
+        assert len(state["by_class"]["wall"]) == 1
         assert len(state["raw_detections"]) == 1
         assert state["raw_detections"][0]["class_name"] == "wall"
+
+
+# ── detect_to_game_state() — generic API ────────────────────────────
+
+
+class TestDetectToGameStateGeneric:
+    """Tests for the generic (game-agnostic) detect_to_game_state API.
+
+    After the refactor, detect_to_game_state returns a generic dict
+    keyed by class name with lists of normalised bboxes sorted by
+    confidence descending.
+    """
+
+    def test_returns_by_class_dict(self):
+        """detect_to_game_state returns a 'by_class' dict keyed by class name."""
+        detector = _make_detector_with_mock_model(
+            boxes_data=[
+                (0, 0.95, (280, 440, 360, 460)),  # paddle
+                (1, 0.90, (310, 200, 330, 220)),  # ball
+            ],
+        )
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        state = detector.detect_to_game_state(frame, 640, 480)
+
+        assert "by_class" in state
+        assert "paddle" in state["by_class"]
+        assert "ball" in state["by_class"]
+
+    def test_by_class_lists_contain_tuples(self):
+        """Each class entry is a list of (cx, cy, w, h, conf) tuples."""
+        detector = _make_detector_with_mock_model(
+            boxes_data=[
+                (2, 0.80, (100, 50, 150, 70)),  # brick
+            ],
+        )
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        state = detector.detect_to_game_state(frame, 640, 480)
+
+        bricks = state["by_class"]["brick"]
+        assert len(bricks) == 1
+        assert len(bricks[0]) == 5  # (cx, cy, w, h, conf)
+        assert bricks[0][4] == pytest.approx(0.80)  # confidence
+
+    def test_multiple_detections_sorted_by_confidence_desc(self):
+        """Multiple detections per class are sorted by confidence descending."""
+        detector = _make_detector_with_mock_model(
+            boxes_data=[
+                (2, 0.60, (100, 50, 150, 70)),  # brick low conf
+                (2, 0.95, (200, 50, 250, 70)),  # brick high conf
+                (2, 0.75, (300, 50, 350, 70)),  # brick mid conf
+            ],
+        )
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        state = detector.detect_to_game_state(frame, 640, 480)
+
+        bricks = state["by_class"]["brick"]
+        assert len(bricks) == 3
+        confs = [b[4] for b in bricks]
+        assert confs == sorted(confs, reverse=True)
+
+    def test_empty_detections_returns_empty_by_class(self):
+        """Empty detections return empty by_class dict."""
+        detector = _make_detector_with_mock_model(boxes_data=[])
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        state = detector.detect_to_game_state(frame, 640, 480)
+
+        assert state["by_class"] == {}
+        assert state["raw_detections"] == []
+
+    def test_raw_detections_preserved(self):
+        """raw_detections key still contains the full detection list."""
+        detector = _make_detector_with_mock_model(
+            boxes_data=[
+                (0, 0.95, (280, 440, 360, 460)),  # paddle
+            ],
+        )
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        state = detector.detect_to_game_state(frame, 640, 480)
+
+        assert len(state["raw_detections"]) == 1
+        assert state["raw_detections"][0]["class_name"] == "paddle"
+
+    def test_normalisation_uses_provided_dimensions(self):
+        """Normalisation uses frame_width/frame_height parameters."""
+        detector = _make_detector_with_mock_model(
+            boxes_data=[
+                (0, 0.95, (0, 0, 100, 50)),  # paddle at top-left
+            ],
+        )
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        state = detector.detect_to_game_state(frame, 1000, 500)
+
+        paddles = state["by_class"]["paddle"]
+        assert len(paddles) == 1
+        cx, cy, w, h, conf = paddles[0]
+        assert cx == pytest.approx(0.05, abs=0.001)
+        assert cy == pytest.approx(0.05, abs=0.001)
+        assert w == pytest.approx(100 / 1000, abs=0.001)
+        assert h == pytest.approx(50 / 500, abs=0.001)
+
+    def test_all_classes_represented(self):
+        """All detected class names appear in by_class."""
+        detector = _make_detector_with_mock_model(
+            boxes_data=[
+                (0, 0.95, (280, 440, 360, 460)),  # paddle
+                (1, 0.90, (310, 200, 330, 220)),  # ball
+                (2, 0.80, (100, 50, 150, 70)),  # brick
+                (3, 0.60, (300, 300, 320, 320)),  # powerup
+                (4, 0.80, (0, 0, 640, 10)),  # wall
+            ],
+        )
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        state = detector.detect_to_game_state(frame, 640, 480)
+
+        assert set(state["by_class"].keys()) == {"paddle", "ball", "brick", "powerup", "wall"}
+
+    def test_no_legacy_breakout_keys_at_top_level(self):
+        """The generic API does not have Breakout-specific top-level keys."""
+        detector = _make_detector_with_mock_model(
+            boxes_data=[
+                (0, 0.95, (280, 440, 360, 460)),  # paddle
+                (1, 0.90, (310, 200, 330, 220)),  # ball
+            ],
+        )
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        state = detector.detect_to_game_state(frame, 640, 480)
+
+        # These should NOT be top-level keys anymore
+        assert "paddle" not in state
+        assert "ball" not in state
+        assert "bricks" not in state
+        assert "powerups" not in state
 
 
 # ── breakout_capture ────────────────────────────────────────────────
@@ -593,10 +724,10 @@ class TestBreakoutCapture:
 
         mock_detector = mock.MagicMock()
         expected_state = {
-            "paddle": (0.5, 0.9, 0.1, 0.05),
-            "ball": (0.5, 0.5, 0.02, 0.02),
-            "bricks": [],
-            "powerups": [],
+            "by_class": {
+                "paddle": [(0.5, 0.9, 0.1, 0.05, 0.95)],
+                "ball": [(0.5, 0.5, 0.02, 0.02, 0.90)],
+            },
             "raw_detections": [],
         }
         mock_detector.detect_to_game_state.return_value = expected_state


### PR DESCRIPTION
## Summary

- Refactor `YoloDetector.detect_to_game_state()` to remove Breakout-specific grouping logic from the platform-level detector
- The method now returns a generic `{"by_class": {"paddle": [(cx, cy, w, h, conf), ...], ...}, "raw_detections": [...]}` format
- Game-specific interpretation (e.g., picking highest-confidence paddle, collecting all bricks) moves to each plugin's `_detect_objects()` override

## Changes

### Production code
- **`src/perception/yolo_detector.py`** — `detect_to_game_state()` refactored: groups detections by class name with confidence scores, sorted descending by confidence. No longer hardcodes Breakout class names.
- **`games/breakout71/env.py`** — New `_detect_objects()` override converts generic format → Breakout-specific format (single paddle/ball via highest confidence, all bricks/powerups as coordinate tuples).
- **`src/platform/base_env.py`** — `_detect_objects()` docstring updated to describe the new generic input format.
- **`src/perception/breakout_capture.py`** — Docstrings updated for generic format.
- **`scripts/debug_pixel_loop.py`** — 3 call sites updated to use `by_class` dict.

### Test code
- **`tests/test_perception.py`** — `TestYoloDetectorGameState` updated for new API; 8 new tests in `TestDetectToGameStateGeneric`.
- **`tests/test_env.py`** — `_generic_detections()` helper added; 14 `detect_to_game_state` mock sites + 2 `TestDetectObjects` tests updated.
- **`tests/test_base_env.py`** — StubEnv gets `_detect_objects()` override; `_generic_make_detections()` helper; 8 mock sites updated.
- **`tests/test_orchestrator.py`** — 2 inline detection dicts converted to generic format.
- **`tests/test_browser_crash_recovery.py`** — StubEnv gets `_detect_objects()` override; 1 mock site updated.
- **`tests/test_cnn_wrapper.py`** — `_generic_detections()` helper; 2 mock sites updated.

## Motivation

`detect_to_game_state()` was the last piece of Breakout-specific logic in the platform-level perception module. This refactor completes roadmap task `dep.detect`, making the perception layer fully game-agnostic and ready for any new game plugin without modification.

## Testing

- Full test suite: **1610 passed, 12 skipped, 95.15% coverage**
- Local CI (act): all 4 jobs pass (Lint, Test, Build Check, Build Docs)