### PR TITLE
refactor: extract reward computation into games/breakout71/reward.py

### DIFF
--- a/games/breakout71/env.py
+++ b/games/breakout71/env.py
@@ -62,6 +62,7 @@ from games.breakout71.modal_handler import (
     MOVE_MOUSE_JS,
     READ_GAME_STATE_JS,
 )
+from games.breakout71.reward import RewardState, compute_breakout_reward
 from src.platform.base_env import BaseGameEnv
 
 logger = logging.getLogger(__name__)
@@ -406,6 +407,9 @@ class Breakout71Env(BaseGameEnv):
     ) -> float:
         """Compute the reward for the current step.
 
+        Delegates to :func:`games.breakout71.reward.compute_breakout_reward`
+        for the actual computation.
+
         Parameters
         ----------
         detections : dict[str, Any]
@@ -427,32 +431,25 @@ class Breakout71Env(BaseGameEnv):
         if score is None:
             game_state = self._read_game_state()
             score = game_state.get("score", 0)
+        assert isinstance(score, int)  # narrowing for type checker
 
-        # Brick destruction reward
-        bricks_left = len(detections.get("bricks", []))
-        bricks_total = self._bricks_total if self._bricks_total else 1
-        bricks_norm = bricks_left / bricks_total
-        brick_delta = self._prev_bricks_norm - bricks_norm
-        reward = brick_delta * 10.0
+        state = RewardState(
+            prev_bricks_norm=self._prev_bricks_norm,
+            bricks_total=self._bricks_total,
+            prev_score=self._prev_score,
+        )
 
-        # Score delta reward (JS bridge)
-        score_delta = score - self._prev_score
-        reward += score_delta * 0.01
+        reward, new_state = compute_breakout_reward(
+            detections=detections,
+            terminated=terminated,
+            level_cleared=level_cleared,
+            score=score,
+            state=state,
+        )
 
-        # Time penalty
-        reward -= 0.01
-
-        # Terminal rewards
-        if terminated and not level_cleared:
-            reward -= 5.0
-
-        # Level cleared bonus (awarded whether or not episode continues)
-        if level_cleared:
-            reward += 1.0
-
-        # Update state for next step
-        self._prev_bricks_norm = bricks_norm
-        self._prev_score = score
+        # Write updated state back to env attributes
+        self._prev_bricks_norm = new_state.prev_bricks_norm
+        self._prev_score = new_state.prev_score
 
         return reward
 

--- a/games/breakout71/reward.py
+++ b/games/breakout71/reward.py
@@ -1,0 +1,121 @@
+"""Breakout 71 reward computation.
+
+Pure-function reward logic extracted from ``Breakout71Env.compute_reward()``.
+All state is passed in via :class:`RewardState` and returned as a new
+instance, making the function fully testable without environment
+instantiation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BRICK_REWARD_SCALE: float = 10.0
+"""Reward multiplier per normalised brick-destruction delta."""
+
+SCORE_REWARD_SCALE: float = 0.01
+"""Reward multiplier per JS score-delta point."""
+
+TIME_PENALTY: float = 0.01
+"""Small negative reward applied every step to discourage idling."""
+
+DEATH_PENALTY: float = 5.0
+"""Penalty subtracted when the episode terminates without clearing the level."""
+
+LEVEL_CLEAR_BONUS: float = 1.0
+"""Bonus added when the level is cleared (all bricks destroyed)."""
+
+
+# ---------------------------------------------------------------------------
+# State container
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RewardState:
+    """Immutable snapshot of reward-relevant state between steps.
+
+    Parameters
+    ----------
+    prev_bricks_norm : float
+        Normalised brick count from the previous step (1.0 = all bricks).
+    bricks_total : int | None
+        Total brick count recorded at episode start.  ``None`` until the
+        first observation sets it.
+    prev_score : int
+        Game score at the end of the previous step.
+    """
+
+    prev_bricks_norm: float = 1.0
+    bricks_total: int | None = None
+    prev_score: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Pure reward function
+# ---------------------------------------------------------------------------
+
+
+def compute_breakout_reward(
+    detections: dict[str, Any],
+    terminated: bool,
+    level_cleared: bool,
+    score: int,
+    state: RewardState,
+) -> tuple[float, RewardState]:
+    """Compute the reward for a single Breakout 71 step.
+
+    Parameters
+    ----------
+    detections : dict[str, Any]
+        Current game-specific detections dict (must contain ``"bricks"``).
+    terminated : bool
+        Whether the episode ended this step.
+    level_cleared : bool
+        Whether the level was cleared (all bricks destroyed).
+    score : int
+        Current game score (from JS bridge or explicit argument).
+    state : RewardState
+        Reward state from the previous step.
+
+    Returns
+    -------
+    tuple[float, RewardState]
+        ``(reward, new_state)`` where *new_state* carries updated
+        ``prev_bricks_norm`` and ``prev_score`` for the next call.
+    """
+    # Brick destruction reward
+    bricks_left = len(detections.get("bricks", []))
+    bricks_total = state.bricks_total if state.bricks_total else 1
+    bricks_norm = bricks_left / bricks_total
+    brick_delta = state.prev_bricks_norm - bricks_norm
+    reward = brick_delta * BRICK_REWARD_SCALE
+
+    # Score delta reward
+    score_delta = score - state.prev_score
+    reward += score_delta * SCORE_REWARD_SCALE
+
+    # Time penalty
+    reward -= TIME_PENALTY
+
+    # Terminal rewards
+    if terminated and not level_cleared:
+        reward -= DEATH_PENALTY
+
+    # Level cleared bonus
+    if level_cleared:
+        reward += LEVEL_CLEAR_BONUS
+
+    # Build new state (frozen dataclass -- use replace())
+    new_state = replace(
+        state,
+        prev_bricks_norm=bricks_norm,
+        prev_score=score,
+    )
+
+    return reward, new_state

--- a/tests/test_breakout_reward.py
+++ b/tests/test_breakout_reward.py
@@ -1,0 +1,240 @@
+"""Tests for the Breakout 71 reward module.
+
+Tests the extracted ``compute_breakout_reward()`` function which
+computes rewards based on brick destruction, score deltas, time
+penalties, and terminal/level-clear bonuses.
+"""
+
+from games.breakout71.reward import RewardState, compute_breakout_reward
+
+# -- Helpers ----------------------------------------------------------------
+
+
+def _detections(bricks=None, **_kw):
+    """Build minimal Breakout-specific detections dict for reward tests."""
+    if bricks is None:
+        bricks = [(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)]
+    return {"bricks": bricks}
+
+
+# -- RewardState construction -----------------------------------------------
+
+
+class TestRewardState:
+    """Tests for the RewardState dataclass."""
+
+    def test_default_construction(self):
+        """Default RewardState should have expected initial values."""
+        state = RewardState()
+        assert state.prev_bricks_norm == 1.0
+        assert state.bricks_total is None
+        assert state.prev_score == 0
+
+    def test_custom_construction(self):
+        """RewardState should accept custom values."""
+        state = RewardState(prev_bricks_norm=0.5, bricks_total=20, prev_score=100)
+        assert state.prev_bricks_norm == 0.5
+        assert state.bricks_total == 20
+        assert state.prev_score == 100
+
+
+# -- compute_breakout_reward -----------------------------------------------
+
+
+class TestComputeBreakoutReward:
+    """Tests for the pure compute_breakout_reward function."""
+
+    def test_brick_destruction_reward(self):
+        """Destroying bricks gives positive reward proportional to delta."""
+        state = RewardState(prev_bricks_norm=1.0, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(8)])
+
+        reward, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=False,
+            score=0,
+            state=state,
+        )
+
+        # brick_delta = 1.0 - 0.8 = 0.2; reward = 0.2 * 10 - 0.01 = 1.99
+        assert abs(reward - 1.99) < 1e-6
+
+    def test_time_penalty_only(self):
+        """No brick change gives only time penalty."""
+        state = RewardState(prev_bricks_norm=0.5, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(5)])
+
+        reward, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=False,
+            score=0,
+            state=state,
+        )
+
+        assert abs(reward - (-0.01)) < 1e-6
+
+    def test_game_over_penalty(self):
+        """Game over adds -5.0 penalty on top of time penalty."""
+        state = RewardState(prev_bricks_norm=0.5, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(5)])
+
+        reward, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=True,
+            level_cleared=False,
+            score=0,
+            state=state,
+        )
+
+        # time penalty (-0.01) + game_over (-5.0) = -5.01
+        assert abs(reward - (-5.01)) < 1e-6
+
+    def test_level_cleared_bonus(self):
+        """Level cleared adds +1.0 bonus."""
+        state = RewardState(prev_bricks_norm=0.0, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[])
+
+        reward, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=True,
+            score=0,
+            state=state,
+        )
+
+        # brick_delta = 0.0; time penalty (-0.01) + level_clear (+1.0) = 0.99
+        assert abs(reward - 0.99) < 1e-6
+
+    def test_combined_brick_and_level_clear(self):
+        """Last brick destroyed + level cleared gives both rewards."""
+        state = RewardState(prev_bricks_norm=0.1, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[])
+
+        reward, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=True,
+            score=0,
+            state=state,
+        )
+
+        # brick_delta = 0.1 * 10 = 1.0; + time (-0.01) + level (+1.0) = 1.99
+        assert abs(reward - 1.99) < 1e-6
+
+    def test_score_delta_positive(self):
+        """Score increase contributes positively to reward."""
+        state = RewardState(prev_bricks_norm=1.0, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)])
+
+        reward, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=False,
+            score=100,
+            state=state,
+        )
+
+        # No brick change: score_delta = 100 * 0.01 = 1.0; time = -0.01
+        assert abs(reward - 0.99) < 1e-6
+
+    def test_state_updated_prev_bricks_norm(self):
+        """Returned state should have updated prev_bricks_norm."""
+        state = RewardState(prev_bricks_norm=1.0, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(7)])
+
+        _, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=False,
+            score=0,
+            state=state,
+        )
+
+        assert abs(new_state.prev_bricks_norm - 0.7) < 1e-6
+
+    def test_state_updated_prev_score(self):
+        """Returned state should have updated prev_score."""
+        state = RewardState(prev_bricks_norm=1.0, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(10)])
+
+        _, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=False,
+            score=42,
+            state=state,
+        )
+
+        assert new_state.prev_score == 42
+
+    def test_original_state_not_mutated(self):
+        """The original state object should not be mutated."""
+        state = RewardState(prev_bricks_norm=1.0, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[(0.1 * i, 0.1, 0.05, 0.03) for i in range(5)])
+
+        _, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=False,
+            score=50,
+            state=state,
+        )
+
+        # Original state should be unchanged
+        assert state.prev_bricks_norm == 1.0
+        assert state.prev_score == 0
+        # New state should differ
+        assert new_state.prev_bricks_norm != 1.0
+        assert new_state.prev_score == 50
+
+    def test_bricks_total_none_uses_one(self):
+        """When bricks_total is None, should default to 1 for division."""
+        state = RewardState(prev_bricks_norm=1.0, bricks_total=None, prev_score=0)
+        det = _detections(bricks=[(0.5, 0.1, 0.05, 0.03)])
+
+        reward, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=False,
+            level_cleared=False,
+            score=0,
+            state=state,
+        )
+
+        # bricks_total defaults to 1; bricks_left=1; norm=1.0
+        # brick_delta = 1.0 - 1.0 = 0.0; reward = -0.01
+        assert abs(reward - (-0.01)) < 1e-6
+
+    def test_game_over_with_level_cleared_gives_no_death_penalty(self):
+        """When terminated=True AND level_cleared=True, no death penalty."""
+        state = RewardState(prev_bricks_norm=0.0, bricks_total=10, prev_score=0)
+        det = _detections(bricks=[])
+
+        reward, new_state = compute_breakout_reward(
+            detections=det,
+            terminated=True,
+            level_cleared=True,
+            score=0,
+            state=state,
+        )
+
+        # Death penalty only applies when terminated and NOT level_cleared
+        # So: time (-0.01) + level (+1.0) = 0.99
+        assert abs(reward - 0.99) < 1e-6
+
+    def test_constants_accessible(self):
+        """Module-level reward constants should be importable."""
+        from games.breakout71.reward import (
+            BRICK_REWARD_SCALE,
+            DEATH_PENALTY,
+            LEVEL_CLEAR_BONUS,
+            SCORE_REWARD_SCALE,
+            TIME_PENALTY,
+        )
+
+        assert BRICK_REWARD_SCALE == 10.0
+        assert SCORE_REWARD_SCALE == 0.01
+        assert TIME_PENALTY == 0.01
+        assert DEATH_PENALTY == 5.0
+        assert LEVEL_CLEAR_BONUS == 1.0


### PR DESCRIPTION
## Summary

Extract Breakout71Env.compute_reward() logic into a standalone pure function module `games/breakout71/reward.py`, continuing the dependency decoupling roadmap (task `dep.reward`).

## Changes

- **New file: `games/breakout71/reward.py`** — Contains `RewardState` frozen dataclass and `compute_breakout_reward()` pure function with 5 module-level constants (`BRICK_REWARD_SCALE`, `SCORE_REWARD_SCALE`, `TIME_PENALTY`, `DEATH_PENALTY`, `LEVEL_CLEAR_BONUS`).
- **Modified: `games/breakout71/env.py`** — `compute_reward()` now delegates to the extracted pure function, building `RewardState` from instance attributes and writing results back. Behavior is identical.
- **New file: `tests/test_breakout_reward.py`** — 14 tests covering all reward scenarios: brick destruction, time penalty, game over, level cleared, score delta, state immutability, edge cases.

## Design

The pure function takes all state via an immutable `RewardState` dataclass and returns `(reward, new_state)`, making reward logic independently testable without env instantiation. The env method acts as a thin adapter that reads/writes instance attributes.

## Testing

- 14 new tests, all passing
- Full suite: 1624 passed, 12 skipped, 95.18% coverage
- `reward.py` at 100% coverage
- CI (Lint + Test + Build Check + Build Docs) all pass