### PR TITLE
feat: add score region auto-detection and per-plugin defaults

### DIFF
--- a/games/__init__.py
+++ b/games/__init__.py
@@ -262,7 +262,13 @@ def discover_plugins(registry: GameRegistry | None = None) -> None:
                 continue
             if attr_name == "__all__":
                 continue
-            if attr_name in ("mute_js", "setup_js", "reinit_js", "load_save_js"):
+            if attr_name in (
+                "mute_js",
+                "setup_js",
+                "reinit_js",
+                "load_save_js",
+                "default_score_region",
+            ):
                 extra[attr_name] = val
 
         registry.register(

--- a/games/breakout71/__init__.py
+++ b/games/breakout71/__init__.py
@@ -54,3 +54,7 @@ setup_js = "\n".join(
 # the pointer mismatch caused by newGameState() / Object.assign in restart).
 # Must be executed AFTER the page has fully loaded.
 reinit_js = "window.restart({})"
+
+# Default (x, y, width, height) region for score OCR.
+# The "$0/$10" counter sits in the top-left area of the game zone.
+default_score_region: tuple[int, int, int, int] | None = (340, 5, 250, 45)

--- a/games/hextris/__init__.py
+++ b/games/hextris/__init__.py
@@ -43,3 +43,7 @@ mute_js = """(function() {
 
 # No setup_js needed — Hextris has no training-specific settings to configure.
 # No reinit_js needed — init(1) handles game restart (done in DISMISS_GAME_OVER_JS).
+
+# Default (x, y, width, height) region for score OCR.
+# The score counter sits above the central hexagon.
+default_score_region: tuple[int, int, int, int] | None = (540, 402, 200, 80)

--- a/games/shapez/__init__.py
+++ b/games/shapez/__init__.py
@@ -45,3 +45,7 @@ setup_js = SETUP_TRAINING_JS
 # JS snippet to load a savegame from JSON data (arguments[0]).
 # Used by SavegameInjector for starting episodes from mid-game states.
 load_save_js = LOAD_SAVE_JS
+
+# Default (x, y, width, height) region for score OCR.
+# shapez.io does not display a simple numeric score; None disables OCR.
+default_score_region: tuple[int, int, int, int] | None = None

--- a/scripts/train_rl.py
+++ b/scripts/train_rl.py
@@ -1150,6 +1150,10 @@ def main(argv: list[str] | None = None) -> int:
             except (ValueError, TypeError) as exc:
                 raise ValueError(f"--score-region must be X,Y,W,H (4 integers): {exc}") from exc
 
+        # Fall back to plugin default_score_region if CLI arg not provided
+        if score_region is None:
+            score_region = getattr(plugin, "default_score_region", None)
+
         # -- Pixel-based game-over detector (optional) ---------------------
         detector = None
         if args.game_over_detector:

--- a/src/orchestrator/session_runner.py
+++ b/src/orchestrator/session_runner.py
@@ -302,6 +302,10 @@ class SessionRunner:
             yolo_weights if yolo_weights is not None else self._plugin.default_weights
         )
 
+        # Resolve score_region from plugin default if not provided by caller
+        if self.score_region is None:
+            self.score_region = getattr(self._plugin, "default_score_region", None)
+
         self._browser_instance = None
         self._env = None
         self._raw_env = None  # Unwrapped env for oracle/step_count access

--- a/src/platform/score_ocr.py
+++ b/src/platform/score_ocr.py
@@ -12,6 +12,10 @@ region : tuple[int, int, int, int] or None
 ocr_interval : int
     Run OCR every N calls to :meth:`read_score`.  Between calls,
     the last cached score is returned.  Default ``1`` (every frame).
+auto_detect : bool
+    When ``True`` and *region* is ``None``, auto-detect the score
+    region on the first :meth:`read_score` call by scanning candidate
+    strips of the frame for numeric text.  Default ``False``.
 """
 
 from __future__ import annotations
@@ -22,6 +26,13 @@ import re
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+# Number of horizontal strips to scan during auto-detection.
+# Each strip spans the full frame width.
+_AUTO_DETECT_STRIPS = 4
+
+# Height fraction of the frame for each candidate strip.
+_STRIP_HEIGHT_FRAC = 0.10
 
 
 class ScoreOCR:
@@ -47,9 +58,12 @@ class ScoreOCR:
         self,
         region: tuple[int, int, int, int] | None = None,
         ocr_interval: int = 1,
+        auto_detect: bool = False,
     ) -> None:
         self._region = region
         self._interval = max(ocr_interval, 1)
+        self._auto_detect = auto_detect
+        self._auto_detect_done: bool = region is not None
         self._frame_count: int = 0
         self._last_score: int | None = None
 
@@ -67,6 +81,14 @@ class ScoreOCR:
             Detected score, or ``None`` if no number was found
             or OCR is unavailable.
         """
+        # Auto-detect region on the very first call if requested
+        if self._auto_detect and not self._auto_detect_done:
+            self._auto_detect_done = True
+            detected = detect_score_region(frame)
+            if detected is not None:
+                self._region = detected
+                logger.info("Auto-detected score region: %s", detected)
+
         self._frame_count += 1
 
         # Throttle: only run OCR on designated frames
@@ -193,3 +215,65 @@ class ScoreOCR:
                 continue
 
         return max(scores) if scores else None
+
+
+# -----------------------------------------------------------------------
+# Standalone auto-detection function
+# -----------------------------------------------------------------------
+
+# Regex: sequences of digits, optionally separated by commas/periods.
+_NUMBER_RE = re.compile(r"\d[\d,.]*\d|\d")
+
+
+def detect_score_region(
+    frame: np.ndarray,
+) -> tuple[int, int, int, int] | None:
+    """Heuristically detect a score region by scanning candidate strips.
+
+    Scans horizontal strips at the top and bottom of the frame (where
+    scores typically appear) and runs OCR on each strip.  Returns the
+    first strip where OCR detects at least one number, as an
+    ``(x, y, width, height)`` tuple.
+
+    Parameters
+    ----------
+    frame : np.ndarray
+        BGR or grayscale game frame.
+
+    Returns
+    -------
+    tuple[int, int, int, int] or None
+        ``(x, y, w, h)`` of the detected region, or ``None`` if no
+        numeric text was found in any candidate strip.
+    """
+    try:
+        import pytesseract
+    except ImportError:
+        logger.debug("pytesseract not installed; score region detection disabled")
+        return None
+
+    fh, fw = frame.shape[:2]
+    strip_h = max(int(fh * _STRIP_HEIGHT_FRAC), 20)
+
+    # Candidate strips: top-left, top-right, bottom-left, bottom-right
+    candidates = [
+        (0, 0, fw, strip_h),  # full top strip
+        (0, fh - strip_h, fw, strip_h),  # full bottom strip
+        (0, 0, fw // 2, strip_h),  # top-left half
+        (fw // 2, 0, fw - fw // 2, strip_h),  # top-right half
+    ]
+
+    for x, y, w, h in candidates:
+        crop = frame[y : y + h, x : x + w]
+        # Convert to grayscale if needed
+        gray = crop.mean(axis=2).astype(np.uint8) if crop.ndim == 3 else crop
+
+        try:
+            text = pytesseract.image_to_string(gray)
+        except Exception:
+            continue
+
+        if _NUMBER_RE.search(text or ""):
+            return (x, y, w, h)
+
+    return None

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -363,6 +363,22 @@ class TestSessionRunnerConstruction:
         assert isinstance(runner.yolo_weights, Path)
         assert isinstance(runner.output_dir, Path)
 
+    def test_score_region_defaults_from_plugin(self):
+        """When score_region is None, SessionRunner reads plugin default_score_region."""
+        runner = SessionRunner(game="hextris")
+        # Hextris plugin defines default_score_region = (540, 402, 200, 80)
+        assert runner.score_region == (540, 402, 200, 80)
+
+    def test_score_region_cli_overrides_plugin_default(self):
+        """Explicit score_region takes priority over plugin default."""
+        runner = SessionRunner(game="hextris", score_region=(10, 20, 100, 30))
+        assert runner.score_region == (10, 20, 100, 30)
+
+    def test_score_region_none_when_plugin_has_no_default(self):
+        """When plugin has no default_score_region, score_region stays None."""
+        runner = SessionRunner(game="shapez")
+        assert runner.score_region is None
+
 
 # ===========================================================================
 # SessionRunner._run_episode Tests (mocked subsystems)

--- a/tests/test_score_ocr.py
+++ b/tests/test_score_ocr.py
@@ -443,3 +443,250 @@ class TestThresholdPreprocessing:
         assert processed.dtype == np.uint8
         unique_vals = set(np.unique(processed))
         assert unique_vals <= {0, 255}
+
+
+# ---------------------------------------------------------------------------
+# detect_score_region (standalone function)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectScoreRegion:
+    """Test heuristic score region auto-detection."""
+
+    def test_detect_score_region_exists_as_function(self):
+        """detect_score_region is importable from score_ocr module."""
+        from src.platform.score_ocr import detect_score_region
+
+        assert callable(detect_score_region)
+
+    def test_returns_tuple_of_four_ints_when_score_found(self):
+        """Returns (x, y, w, h) tuple when a numeric region is found."""
+        from src.platform.score_ocr import detect_score_region
+
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        # Simulate OCR finding a score in a candidate region
+        mock_pytesseract.image_to_string.return_value = "Score: 1234"
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            result = detect_score_region(frame)
+
+        assert result is not None
+        assert len(result) == 4
+        x, y, w, h = result
+        assert isinstance(x, int)
+        assert isinstance(y, int)
+        assert isinstance(w, int)
+        assert isinstance(h, int)
+
+    def test_returns_none_when_no_score_found(self):
+        """Returns None when no candidate region contains numbers."""
+        from src.platform.score_ocr import detect_score_region
+
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = ""
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            result = detect_score_region(frame)
+
+        assert result is None
+
+    def test_returns_none_when_pytesseract_missing(self):
+        """Returns None gracefully when pytesseract is not installed."""
+        from src.platform.score_ocr import detect_score_region
+
+        frame = _make_frame(480, 640)
+
+        with mock.patch.dict("sys.modules", {"pytesseract": None}):
+            result = detect_score_region(frame)
+
+        assert result is None
+
+    def test_region_within_frame_bounds(self):
+        """Returned region is within the frame boundaries."""
+        from src.platform.score_ocr import detect_score_region
+
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "42"
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            result = detect_score_region(frame)
+
+        if result is not None:
+            x, y, w, h = result
+            assert x >= 0
+            assert y >= 0
+            assert x + w <= 640
+            assert y + h <= 480
+
+    def test_scans_top_strip_of_frame(self):
+        """Auto-detection checks the top portion of the frame (scores are typically at top or bottom)."""
+        from src.platform.score_ocr import detect_score_region
+
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        # Only return a score for the first call (top strip)
+        call_count = 0
+
+        def _side_effect(img):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return "Score: 999"
+            return ""
+
+        mock_pytesseract.image_to_string.side_effect = _side_effect
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            result = detect_score_region(frame)
+
+        # Should find a region since the first candidate returned digits
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# ScoreOCR auto_detect parameter
+# ---------------------------------------------------------------------------
+
+
+class TestScoreOCRAutoDetect:
+    """Test ScoreOCR auto_detect parameter for automatic region detection."""
+
+    def test_auto_detect_parameter_accepted(self):
+        """ScoreOCR accepts auto_detect parameter."""
+        ocr = ScoreOCR(auto_detect=True)
+        assert ocr._auto_detect is True
+
+    def test_auto_detect_defaults_to_false(self):
+        """auto_detect defaults to False for backward compatibility."""
+        ocr = ScoreOCR()
+        assert ocr._auto_detect is False
+
+    def test_auto_detect_sets_region_on_first_read(self):
+        """When auto_detect=True and region=None, region is set on first read_score()."""
+        ocr = ScoreOCR(auto_detect=True)
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "Score: 500"
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            with mock.patch(
+                "src.platform.score_ocr.detect_score_region",
+                return_value=(10, 5, 200, 40),
+            ):
+                ocr.read_score(frame)
+
+        # Region should now be set
+        assert ocr._region == (10, 5, 200, 40)
+
+    def test_auto_detect_skipped_when_region_already_set(self):
+        """When region is already provided, auto_detect does not override it."""
+        ocr = ScoreOCR(region=(100, 200, 150, 50), auto_detect=True)
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "42"
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            with mock.patch("src.platform.score_ocr.detect_score_region") as mock_detect:
+                ocr.read_score(frame)
+
+        # detect_score_region should NOT have been called
+        mock_detect.assert_not_called()
+        assert ocr._region == (100, 200, 150, 50)
+
+    def test_auto_detect_only_runs_once(self):
+        """Auto-detection only runs on the first read_score() call, not subsequent ones."""
+        ocr = ScoreOCR(auto_detect=True)
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "100"
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            with mock.patch(
+                "src.platform.score_ocr.detect_score_region",
+                return_value=(10, 5, 200, 40),
+            ) as mock_detect:
+                ocr.read_score(frame)
+                ocr.read_score(frame)
+                ocr.read_score(frame)
+
+        # Only called once (on first read)
+        assert mock_detect.call_count == 1
+
+    def test_auto_detect_falls_back_gracefully_when_detection_fails(self):
+        """When auto-detect returns None, OCR uses full frame (no crash)."""
+        ocr = ScoreOCR(auto_detect=True)
+        frame = _make_frame(480, 640)
+        mock_pytesseract = mock.MagicMock()
+        mock_pytesseract.image_to_string.return_value = "77"
+
+        with mock.patch.dict("sys.modules", {"pytesseract": mock_pytesseract}):
+            with mock.patch(
+                "src.platform.score_ocr.detect_score_region",
+                return_value=None,
+            ):
+                score = ocr.read_score(frame)
+
+        # Should still read the score from full frame
+        assert score == 77
+        # Region stays None
+        assert ocr._region is None
+
+
+# ---------------------------------------------------------------------------
+# Plugin default_score_region metadata
+# ---------------------------------------------------------------------------
+
+
+class TestPluginDefaultScoreRegion:
+    """Test that game plugins can export default_score_region metadata."""
+
+    def test_discover_plugins_collects_default_score_region(self):
+        """discover_plugins collects default_score_region into PluginEntry.extra."""
+        from games import GameRegistry, discover_plugins
+
+        mock_module = mock.MagicMock()
+        mock_module.env_class = type("MockEnv", (), {})
+        mock_module.loader_class = None
+        mock_module.game_name = "test-game"
+        mock_module.default_config = "configs/games/test.yaml"
+        mock_module.default_weights = ""
+        mock_module.default_score_region = (100, 10, 200, 50)
+        # Make dir() return the expected attributes
+        mock_module.__dir__ = lambda self: [
+            "env_class",
+            "loader_class",
+            "game_name",
+            "default_config",
+            "default_weights",
+            "default_score_region",
+        ]
+
+        registry = GameRegistry()
+        with mock.patch("games.pkgutil.iter_modules", return_value=[("", "mockgame", True)]):
+            with mock.patch("games.importlib.import_module", return_value=mock_module):
+                discover_plugins(registry)
+
+        entry = registry.get("mockgame")
+        assert entry is not None
+        assert entry.extra.get("default_score_region") == (100, 10, 200, 50)
+
+    def test_plugin_entry_extra_contains_score_region_when_present(self):
+        """PluginEntry.extra stores default_score_region from plugin module."""
+        from games import GameRegistry
+
+        registry = GameRegistry()
+        registry.register(
+            "test",
+            env_class=type("E", (), {}),
+            loader_class=None,
+            game_name="test",
+            default_config="c.yaml",
+            default_weights="",
+            default_score_region=(540, 402, 200, 80),
+        )
+        entry = registry.get("test")
+        assert entry is not None
+        assert entry.extra["default_score_region"] == (540, 402, 200, 80)


### PR DESCRIPTION
## Summary

- Add `detect_score_region(frame)` heuristic function that scans top/bottom horizontal strips for numeric text via OCR to auto-detect score display location
- Add `auto_detect` parameter to `ScoreOCR` — when `region=None` and `auto_detect=True`, auto-detects region on first `read_score()` call
- Add per-plugin `default_score_region` metadata to all 3 game plugins (breakout71, hextris, shapez), collected by `discover_plugins()` via the extra attribute whitelist
- `SessionRunner` and `train_rl.py` fall back to `plugin.default_score_region` when `--score-region` is not provided, removing the need for users to manually specify score regions for supported games

## Changes

| File | Change |
|---|---|
| `src/platform/score_ocr.py` | `detect_score_region()` function, `auto_detect` param on `ScoreOCR` |
| `games/__init__.py` | Updated `discover_plugins()` extra whitelist for `default_score_region` |
| `games/breakout71/__init__.py` | `default_score_region = (340, 5, 250, 45)` |
| `games/hextris/__init__.py` | `default_score_region = (540, 402, 200, 80)` |
| `games/shapez/__init__.py` | `default_score_region = None` |
| `src/orchestrator/session_runner.py` | Fallback to `plugin.default_score_region` |
| `scripts/train_rl.py` | Fallback to `plugin.default_score_region` |
| `tests/test_score_ocr.py` | 11 new tests (detect + auto-detect + plugin defaults) |
| `tests/test_orchestrator.py` | 3 new tests for plugin default resolution |

## Testing

- 17 new tests across 4 test classes
- 1656 tests pass, 95.04% coverage
- Pre-commit CI passed (Lint, Test, Build Check, Build Docs)