### PR TITLE
chore: add .agentguard/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ node_modules/
 # Private OpenCode data (credentials, local state)
 .opencode/
 
+# AgentGuard local policies (per-project, never commit)
+.agentguard/
+
 # OpenCode project config (contains local paths, not for repo)
 opencode.json
 


### PR DESCRIPTION
## Summary
- Adds `.agentguard/` to `.gitignore` to exclude local AgentGuard policy overrides from version control
- Part of the AgentGuard MCP server rollout across all RSN repos