### PR TITLE
ci: add sb3-contrib and ncps dependencies to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
             pygame==2.6.1 \
             ultralytics==8.4.14 \
             stable-baselines3==2.7.1 \
+            sb3-contrib==2.7.1 \
+            "ncps>=1.0.0" \
             scipy==1.17.0 \
             matplotlib==3.10.8 \
             pyyaml==6.0.3 \
@@ -110,6 +112,8 @@ jobs:
             pygame==2.6.1 \
             ultralytics==8.4.14 \
             stable-baselines3==2.7.1 \
+            sb3-contrib==2.7.1 \
+            "ncps>=1.0.0" \
             scipy==1.17.0 \
             matplotlib==3.10.8 \
             pyyaml==6.0.3 \
@@ -161,6 +165,8 @@ jobs:
             pygame==2.6.1 \
             ultralytics==8.4.14 \
             stable-baselines3==2.7.1 \
+            sb3-contrib==2.7.1 \
+            "ncps>=1.0.0" \
             scipy==1.17.0 \
             matplotlib==3.10.8 \
             pyyaml==6.0.3 \


### PR DESCRIPTION
## Summary

- Add `sb3-contrib==2.7.1` and `ncps>=1.0.0` to Test, Build Check, and Build Docs CI jobs
- Required by the CNN+CfC liquid neural network policy added in PR #164
- CI on main is currently failing because these dependencies are missing

This is a one-line-per-job change (6 lines total) to add the new dependencies that were part of PR #164 but couldn't be pushed due to missing `workflow` scope on the OAuth token.